### PR TITLE
Support Gradle 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [Unreleased]
+### Changed
+ - Remove dependency on Gradle Script Kotlin plugin API. (#9)
+ - Compatibility with Gradle v4.0. (#9)
+
 ## [2.0.0] - 2017-05-26
 ### Changed
  - Renamed task with name `ktlint` to `ktlintCheck` (#3)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.jlleitschuh.gradle"
-version = "2.0.0"
+version = "2.0.1-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -17,8 +17,12 @@ repositories {
 
 dependencies {
     compileOnly(gradleApi())
-    compileOnly(gradleScriptKotlinApi())
     compileOnly(kotlinModule("gradle-plugin", "1.1.1"))
+    /*
+     * Do not depend upon the gradle script kotlin plugin API. IE: gradleScriptKotlinApi()
+     * It's currently in flux and has binary breaking changes in gradle 4.0
+     * https://github.com/JLLeitschuh/ktlint-gradle/issues/9
+     */
 }
 
 configure<PublishingExtension> {


### PR DESCRIPTION
This removes the dependency upon the gradle script kotlin API
The API has changed in gradle 4.0 and does not have binary compatibility.

Closes #9