### PR TITLE
Issue #8 - Add support for Android projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+ - Android support
+ - Ability to only apply plugin to the root project that contains subprojects with kotlin code
 
 ## [2.0.1] - 2017-06-1
 ### Changed

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ ktlint {
 
 This plugin adds two tasks to every source set: `ktlint[source set name]Check` and `ktlint[source set name]Format`.
 Additionally, a simple `ktlintCheck` task has also been added that checks all of the source sets for that project.
-Similarly, a `ktlintFormat` task has been added that formats all of the source sets. Also same meta tasks are added
-to the root project for convenience - they will call related tasks in subprojects. 
+Similarly, a `ktlintFormat` task has been added that formats all of the source sets.
+
+If project has subprojects - plugin also adds two meta tasks `ktlintCheck` and `ktlintFormat` to the root project that 
+triggers related tasks in subprojects.
 
 
 ## Developers

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ ktlint {
 
 This plugin adds two tasks to every source set: `ktlint[source set name]Check` and `ktlint[source set name]Format`.
 Additionally, a simple `ktlintCheck` task has also been added that checks all of the source sets for that project.
-Similarly, a `ktlintFormat` task has been added that formats all of the source sets.
+Similarly, a `ktlintFormat` task has been added that formats all of the source sets. Also same meta tasks are added
+to the root project for convenience - they will call related tasks in subprojects. 
 
 
 ## Developers

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,13 @@ group = "org.jlleitschuh.gradle"
 version = "2.0.1"
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 dependencies {
     compileOnly(gradleApi())
     compileOnly(kotlinModule("gradle-plugin", "1.1.1"))
+    compileOnly("com.android.tools.build:gradle:2.3.2")
     /*
      * Do not depend upon the gradle script kotlin plugin API. IE: gradleScriptKotlinApi()
      * It's currently in flux and has binary breaking changes in gradle 4.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 dependencies {
     compileOnly(gradleApi())
     compileOnly(kotlinModule("gradle-plugin", "1.1.1"))
-    compileOnly("com.android.tools.build:gradle:2.3.2")
+    compileOnly("com.android.tools.build:gradle:2.3.3")
     /*
      * Do not depend upon the gradle script kotlin plugin API. IE: gradleScriptKotlinApi()
      * It's currently in flux and has binary breaking changes in gradle 4.0

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -1,8 +1,11 @@
 package org.jlleitschuh.gradle.ktlint
 
+import com.android.build.gradle.BaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.HasConvention
 import org.gradle.api.plugins.Convention
@@ -11,69 +14,124 @@ import org.gradle.api.tasks.JavaExec
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import kotlin.reflect.KClass
 
+const val VERIFICATION_GROUP = "Verification"
+const val FORMATTING_GROUP = "Formatting"
+const val CHECK_PARENT_TASK_NAME = "ktlintCheck"
+const val FORMAT_PARENT_TASK_NAME = "ktlintFormat"
+
+
 /**
  * Task that provides a wrapper over the `ktlint` project.
  */
 open class KtlintPlugin : Plugin<Project> {
-    override fun apply(target: Project) {
-        val formattingGroup = "formatting"
-        val verificationGroup = "Verification"
 
+    override fun apply(target: Project) {
         val extension = target.extensions.create("ktlint", KtlintExtension::class.java)
 
-        val ktlintTask = target.task("ktlintCheck").apply {
-            group = verificationGroup
-            description = "Runs ktlint on all kotlin sources in this project."
-        }
-        val ktlintFormatTask = target.task("ktlintFormat").apply {
-            group = formattingGroup
-            description = "Runs the ktlint formatter on all kotlin sources in this project."
-        }
+        addKtLintTasksToKotlinPlugin(target, extension)
+        addKtLintTasksToAndroidKotlinPlugin(target, extension)
+    }
 
-        // Only apply this plugin to projects that have the kotlin plugin applied.
+    private fun addKtLintTasksToKotlinPlugin(target: Project,
+                                             extension: KtlintExtension) {
         target.pluginManager.withPlugin("kotlin") {
-            val ktLintConfig = target.configurations.maybeCreate("ktlint")
+            val ktLintConfig = createConfiguration(target, extension)
 
-            target.dependencies.add(ktLintConfig.name,
-                mapOf("group" to "com.github.shyiko", "name" to "ktlint", "version" to extension.version))
             target.afterEvaluate {
-                val sourceSets = target.theHelper<JavaPluginConvention>().sourceSets
-                sourceSets.forEach {
+                target.theHelper<JavaPluginConvention>().sourceSets.forEach {
                     val kotlinSourceSet: SourceDirectorySet = (it as HasConvention)
-                        .convention
-                        .getPluginHelper<KotlinSourceSet>()
-                        .kotlin
-                    val runArgs = kotlinSourceSet.sourceDirectories.files.map { "${it.path}/**/*.kt" }.toMutableList()
+                            .convention
+                            .getPluginHelper<KotlinSourceSet>()
+                            .kotlin
+                    val runArgs = kotlinSourceSet.sourceDirectories.files.map { "${it.path}/**/*.kt" }.toMutableSet()
+                    addAdditionalRunArgs(extension, runArgs)
 
-                    // Add the args to enable verbose and debug mode.
-                    if (extension.verbose) runArgs.add("--verbose")
-                    if (extension.debug) runArgs.add("--debug")
+                    val checkTask = createCheckTask(target, it.name, ktLintConfig, kotlinSourceSet, runArgs)
+                    getOrCreateParentKtlintCheckTask(target).dependsOn(checkTask)
 
-                    val ktlintSourceSetTask = target.taskHelper<JavaExec>("ktlint${it.name.capitalize()}Check") {
-                        group = verificationGroup
-                        description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
-                        main = "com.github.shyiko.ktlint.Main"
-                        classpath = ktLintConfig
-                        inputs.dir(kotlinSourceSet)
-                        args(runArgs)
-                    }
-                    ktlintTask.dependsOn(ktlintSourceSetTask)
-
-                    val ktlintSourceSetFormatTask = target.taskHelper<JavaExec>("ktlint${it.name.capitalize()}Format") {
-                        group = formattingGroup
-                        description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
-                        main = "com.github.shyiko.ktlint.Main"
-                        classpath = ktLintConfig
-                        inputs.dir(kotlinSourceSet)
-                        // This copies the list
-                        val sourcePathsWithFormatFlag = runArgs.toMutableList()
-                        // Prepend the format flag to the beginning of the list
-                        sourcePathsWithFormatFlag.add(0, "-F")
-                        args(sourcePathsWithFormatFlag)
-                    }
-                    ktlintFormatTask.dependsOn(ktlintSourceSetFormatTask)
+                    val ktlintSourceSetFormatTask = createFormatTask(target, it.name, ktLintConfig, kotlinSourceSet, runArgs)
+                    getOrCreateParentKtlintFormatTask(target).dependsOn(ktlintSourceSetFormatTask)
                 }
             }
+        }
+    }
+
+    private fun addKtLintTasksToAndroidKotlinPlugin(target: Project,
+                                                    extension: KtlintExtension) {
+        target.pluginManager.withPlugin("kotlin-android") {
+            val ktLintConfig = createConfiguration(target, extension)
+
+            target.afterEvaluate {
+                target.extensions.findByType(BaseExtension::class.java).sourceSets.forEach {
+                    val kotlinSourceDir = it.java.sourceFiles
+                    val runArgs = it.java.srcDirs.map { "${it.path}/**/*.kt" }.toMutableSet()
+                    addAdditionalRunArgs(extension, runArgs)
+
+                    val checkTask = createCheckTask(target, it.name, ktLintConfig, kotlinSourceDir, runArgs)
+                    getOrCreateParentKtlintCheckTask(target).dependsOn(checkTask)
+
+                    val ktlintSourceSetFormatTask = createFormatTask(target, it.name, ktLintConfig, kotlinSourceDir, runArgs)
+                    getOrCreateParentKtlintFormatTask(target).dependsOn(ktlintSourceSetFormatTask)
+                }
+            }
+        }
+    }
+
+    private fun createConfiguration(target: Project, extension: KtlintExtension) =
+            target.configurations.maybeCreate("ktlint").apply {
+                target.dependencies.add(this.name,
+                        mapOf("group" to "com.github.shyiko", "name" to "ktlint", "version" to extension.version))
+            }
+
+    private fun addAdditionalRunArgs(extension: KtlintExtension, runArgs: MutableSet<String>) {
+        // Add the args to enable verbose and debug mode.
+        if (extension.verbose) runArgs.add("--verbose")
+        if (extension.debug) runArgs.add("--debug")
+    }
+
+    private fun getOrCreateParentKtlintCheckTask(target: Project) = target.tasks.findByName(CHECK_PARENT_TASK_NAME) ?:
+            target.task(CHECK_PARENT_TASK_NAME).apply {
+                group = VERIFICATION_GROUP
+                description = "Runs ktlint on all kotlin sources in this project."
+            }
+
+    private fun getOrCreateParentKtlintFormatTask(target: Project) = target.tasks.findByName(FORMAT_PARENT_TASK_NAME) ?:
+            target.task(FORMAT_PARENT_TASK_NAME).apply {
+                group = FORMATTING_GROUP
+                description = "Runs the ktlint formatter on all kotlin sources in this project."
+            }
+
+    private fun createFormatTask(target: Project,
+                                 sourceSetName: String,
+                                 ktLintConfig: Configuration,
+                                 kotlinSourceSet: FileCollection,
+                                 runArgs: MutableSet<String>): JavaExec {
+        return target.taskHelper<JavaExec>("ktlint${sourceSetName.capitalize()}Format") {
+            group = FORMATTING_GROUP
+            description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
+            main = "com.github.shyiko.ktlint.Main"
+            classpath = ktLintConfig
+            inputs.dir(kotlinSourceSet)
+            // This copies the list
+            val sourcePathsWithFormatFlag = runArgs.toMutableList()
+            // Prepend the format flag to the beginning of the list
+            sourcePathsWithFormatFlag.add(0, "-F")
+            args(sourcePathsWithFormatFlag)
+        }
+    }
+
+    private fun createCheckTask(target: Project,
+                                sourceSetName: String,
+                                ktLintConfig: Configuration,
+                                kotlinSourceSet: FileCollection,
+                                runArgs: MutableSet<String>): Task {
+        return target.taskHelper<JavaExec>("ktlint${sourceSetName.capitalize()}Check") {
+            group = VERIFICATION_GROUP
+            description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
+            main = "com.github.shyiko.ktlint.Main"
+            classpath = ktLintConfig
+            inputs.dir(kotlinSourceSet)
+            args(runArgs)
         }
     }
 
@@ -88,10 +146,6 @@ open class KtlintPlugin : Plugin<Project> {
     private fun <T : Any> Project.theHelper(extensionType: KClass<T>) =
         convention.findPlugin(extensionType.java) ?: convention.getByType(extensionType.java)!!
 
-
-    private inline fun <reified T : Task> Project.taskHelper(name: String): T {
-        return this.tasks.create(name, T::class.java)!!
-    }
 
     private inline fun <reified T : Task> Project.taskHelper(name: String, noinline configuration: T.() -> Unit): T {
         return this.tasks.create(name, T::class.java, configuration)!!


### PR DESCRIPTION
Fix for issue #8: This pull request adds support for Android projects with applied `kotlin-android` plugin. Also adds applying plugin only to root project - it will scan subprojects and add tasks accordingly.