### PR TITLE
Fix plugin uses always default ktlint version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changed
  - Update default ktlint version to 0.8.1
+ - Fix extension version has no effect on used ktlint version
 
 ## [2.1.0] - 2017-07-5
 ### Added

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -41,9 +41,9 @@ open class KtlintPlugin : Plugin<Project> {
     private fun addKtLintTasksToKotlinPlugin(target: Project,
                                              extension: KtlintExtension) {
         target.pluginManager.withPlugin("kotlin") {
-            val ktLintConfig = createConfiguration(target, extension)
-
             target.afterEvaluate {
+                val ktLintConfig = createConfiguration(target, extension)
+                
                 target.theHelper<JavaPluginConvention>().sourceSets.forEach {
                     val kotlinSourceSet: SourceDirectorySet = (it as HasConvention)
                             .convention
@@ -65,9 +65,9 @@ open class KtlintPlugin : Plugin<Project> {
     private fun addKtLintTasksToAndroidKotlinPlugin(target: Project,
                                                     extension: KtlintExtension) {
         target.pluginManager.withPlugin("kotlin-android") {
-            val ktLintConfig = createConfiguration(target, extension)
-
             target.afterEvaluate {
+                val ktLintConfig = createConfiguration(target, extension)
+                
                 target.extensions.findByType(BaseExtension::class.java).sourceSets.forEach {
                     val kotlinSourceDir = it.java.sourceFiles
                     val runArgs = it.java.srcDirs.map { "${it.path}/**/*.kt" }.toMutableSet()


### PR DESCRIPTION
Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>

During working on issue #13 I found out that plugin always uses default extension version of ktlint, no matter what version is defined in users project.