### PR TITLE
Add output report and report type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Update default ktlint version to 0.8.1
  - Fix extension version has no effect on used ktlint version
  - Add check task also depends on ktlintCheck task
+ - Add output report
+ - Add report type to extension
 
 ## [2.1.0] - 2017-07-5
 ### Added

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ktlint {
     version = ""
     debug = true
     verbose = true
+    reporter = "checkstyle"
 }
 ```
 

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -1,4 +1,4 @@
-package org.jlleitschuh.gradle.ktlint;
+package org.jlleitschuh.gradle.ktlint
 
 /**
  * Extension class for configuring the [KtlintPlugin].
@@ -16,4 +16,14 @@ open class KtlintExtension {
      * Enable debug mode.
      */
     var debug = false
+
+    /**
+     * Report output format.
+     *
+     * Possible values are: plain, checkstyle, json.
+     * By default is plain.
+     *
+     * Available since ktlint version 0.9.0.
+     */
+    var reporter = "plain"
 }

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -20,10 +20,19 @@ open class KtlintExtension {
     /**
      * Report output format.
      *
-     * Possible values are: plain, checkstyle, json.
-     * By default is plain.
+     * Available values: plain, plain_group_by_file, checkstyle, json.
      *
-     * Available since ktlint version 0.9.0.
+     * Default is plain.
      */
-    var reporter = "plain"
+    var reporter: ReporterType  = ReporterType.PLAIN
+
+    /**
+     * Supported reporter types.
+     */
+    enum class ReporterType(val reporterName: String, val availableSinceVersion: String, val fileExtension: String) {
+        PLAIN("plain", "0.9.0", "txt"),
+        PLAIN_GROUP_BY_FILE("plain?group_by_file", "0.9.0", "txt"),
+        CHECKSTYLE("checkstyle", "0.9.0", "xml"),
+        JSON("json", "0.9.0", "json");
+    }
 }

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -24,15 +24,5 @@ open class KtlintExtension {
      *
      * Default is plain.
      */
-    var reporter: ReporterType  = ReporterType.PLAIN
-
-    /**
-     * Supported reporter types.
-     */
-    enum class ReporterType(val reporterName: String, val availableSinceVersion: String, val fileExtension: String) {
-        PLAIN("plain", "0.9.0", "txt"),
-        PLAIN_GROUP_BY_FILE("plain?group_by_file", "0.9.0", "txt"),
-        CHECKSTYLE("checkstyle", "0.9.0", "xml"),
-        JSON("json", "0.9.0", "json");
-    }
+    var reporter: ReporterType = ReporterType.PLAIN
 }

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -102,34 +102,24 @@ open class KtlintPlugin : Plugin<Project> {
     }
 
     private fun addReporter(extension: KtlintExtension, runArgs: MutableSet<String>) {
-        if (isReportAvailable(extension.version)) {
-            runArgs.add("--reporter=${extension.reporter}")
+        if (isReportAvailable(extension.version, extension.reporter.availableSinceVersion)) {
+            runArgs.add("--reporter=${extension.reporter.reporterName}")
         }
     }
 
-    private fun isReportAvailable(version: String): Boolean {
+    private fun isReportAvailable(version: String, availableSinceVersion: String): Boolean {
         val versionsNumbers = version.split('.')
-        if (versionsNumbers[0].toInt() >= 1) {
-            return true
-        } else if (versionsNumbers[1].toInt() >= 9) {
-            return true
-        }
-
-        return false
+        val reporterVersionNumbers = availableSinceVersion.split('.')
+        return versionsNumbers[0] >= reporterVersionNumbers[0] &&
+                versionsNumbers[1] >= reporterVersionNumbers[1] &&
+                versionsNumbers[2] >= reporterVersionNumbers[2]
     }
 
     private fun createCheckTaskOutputDir(target: Project, extension: KtlintExtension): File {
         val reportsDir = File(target.buildDir, "reports/ktlint")
         reportsDir.mkdirs()
-        return File(reportsDir, "ktlint.${getReportFileExtension(extension)}")
+        return File(reportsDir, "ktlint.${extension.reporter.fileExtension}")
     }
-
-    private fun getReportFileExtension(extension: KtlintExtension): String =
-            when(extension.reporter) {
-                "checkstyle" -> "xml"
-                "json" -> "json"
-                else -> "txt"
-            }
 
     private fun addKtlintCheckTaskToProjectMetaCheckTask(target: Project, checkTask: Task) {
         target.getMetaKtlintCheckTask().dependsOn(checkTask)

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
@@ -1,0 +1,44 @@
+// Collection of functions that applies output Ktlint reporter
+
+package org.jlleitschuh.gradle.ktlint
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.JavaExec
+import org.gradle.util.GFileUtils
+import java.io.File
+
+/**
+ * Supported reporter types.
+ */
+enum class ReporterType(val reporterName: String, val availableSinceVersion: String, val fileExtension: String) {
+    PLAIN("plain", "0.9.0", "txt"),
+    PLAIN_GROUP_BY_FILE("plain?group_by_file", "0.9.0", "txt"),
+    CHECKSTYLE("checkstyle", "0.9.0", "xml"),
+    JSON("json", "0.9.0", "json");
+}
+
+/**
+ * Apply reporter to the task.
+ */
+fun JavaExec.applyReporter(target: Project, extension: KtlintExtension) {
+    if (isReportAvailable(extension.version, extension.reporter.availableSinceVersion)) {
+        this.args("--reporter=${extension.reporter.reporterName}")
+        this.standardOutput = createReportOutputDir(target, extension).outputStream()
+    } else {
+        target.logger.info("Reporter is not available in this ktlint version")
+    }
+}
+
+private fun isReportAvailable(version: String, availableSinceVersion: String): Boolean {
+    val versionsNumbers = version.split('.')
+    val reporterVersionNumbers = availableSinceVersion.split('.')
+    return versionsNumbers[0] >= reporterVersionNumbers[0] &&
+            versionsNumbers[1] >= reporterVersionNumbers[1] &&
+            versionsNumbers[2] >= reporterVersionNumbers[2]
+}
+
+private fun createReportOutputDir(target: Project, extension: KtlintExtension): File {
+    val reportsDir = File(target.buildDir, "reports/ktlint")
+    GFileUtils.mkdirs(reportsDir)
+    return File(reportsDir, "ktlint.${extension.reporter.fileExtension}")
+}


### PR DESCRIPTION
Now plugin outputs check task results to build/reports/ktlint/ folder.
Also user can select one of supported report types.
Fixes #13 

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>