### PR TITLE
add ignoreFailures configuration for CI builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] - 2017-09-05
+### Added
+ - Add configuration parameter `ignoreFailures` with default value to false
+### Changed
+ - Update default ktlint version to 0.9.2 
+
 ## [2.1.1] - 2017-08-15
 ### Changed
  - Update default ktlint version to 0.8.1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ ktlint {
     debug = true
     verbose = true
     reporter = "checkstyle"
+    ignoreFailures = true
 }
 ```
 

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -18,6 +18,14 @@ open class KtlintExtension {
     var debug = false
 
     /**
+     * Whether or not to allow the build to continue if there are warnings;
+     * defaults to {@code false}, as for any other static code analysis tool.
+     * <p>
+     * Example: {@code ignoreFailures = true}
+     */
+    var ignoreFailures = false
+
+    /**
      * Report output format.
      *
      * Available values: plain, plain_group_by_file, checkstyle, json.

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -21,7 +21,7 @@ open class KtlintExtension {
      * Whether or not to allow the build to continue if there are warnings;
      * defaults to {@code false}, as for any other static code analysis tool.
      * <p>
-     * Example: {@code ignoreFailures = true}
+     * Example: `ignoreFailures = true`
      */
     var ignoreFailures = false
 

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -143,7 +143,10 @@ open class KtlintPlugin : Plugin<Project> {
             classpath = ktLintConfig
             inputs.dir(kotlinSourceSet)
             args(runArgs)
-        }.apply { this.applyReporter(target, extension) }
+        }.apply {
+            this.isIgnoreExitValue = extension.ignoreFailures
+            this.applyReporter(target, extension)
+        }
     }
 
     private fun Project.getMetaKtlintCheckTask(): Task = this.tasks.findByName(CHECK_PARENT_TASK_NAME) ?:


### PR DESCRIPTION
Allow users to configure whether or not the build should fail if there is some ktlint issues, very useful if getting quality reports from CI.