### PR TITLE
define a different output file for each sourceSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+### Changed
+ - Define a different output file for each sourceSet
 ### Fixed
-- Fixed plugin doesn't apply custom reporter for ktlint versions >0.10.x (#28)
+ - Fixed plugin doesn't apply custom reporter for ktlint versions >0.10.x (#28)
 
 ## [2.2.1] - 2017-10-06
 ### Fixed
-- Fixed report output is always opened since task is created
+ - Fixed report output is always opened since task is created
 
 ## [2.2.0] - 2017-10-05
 ### Added

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -144,7 +144,7 @@ open class KtlintPlugin : Plugin<Project> {
             args(runArgs)
         }.apply {
             this.isIgnoreExitValue = extension.ignoreFailures
-            this.applyReporter(target, extension)
+            this.applyReporter(target, extension, sourceSetName)
         }
     }
 

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
@@ -21,11 +21,11 @@ enum class ReporterType(val reporterName: String, val availableSinceVersion: Str
 /**
  * Apply reporter to the task.
  */
-fun JavaExec.applyReporter(target: Project, extension: KtlintExtension) {
+fun JavaExec.applyReporter(target: Project, extension: KtlintExtension, sourceSetName: String) {
     if (isReportAvailable(extension.version, extension.reporter.availableSinceVersion)) {
         var reportOutput: FileOutputStream? = null
         doFirst {
-            reportOutput = createReportOutputDir(target, extension).outputStream().also {
+            reportOutput = createReportOutputDir(target, extension, sourceSetName).outputStream().also {
                 this.args("--reporter=${extension.reporter.reporterName}")
                 this.standardOutput = it
             }
@@ -44,8 +44,8 @@ private fun isReportAvailable(version: String, availableSinceVersion: String): B
             versionsNumbers[2] >= reporterVersionNumbers[2]
 }
 
-private fun createReportOutputDir(target: Project, extension: KtlintExtension): File {
+private fun createReportOutputDir(target: Project, extension: KtlintExtension, sourceSetName: String): File {
     val reportsDir = File(target.buildDir, "reports/ktlint")
     GFileUtils.mkdirs(reportsDir)
-    return File(reportsDir, "ktlint.${extension.reporter.fileExtension}")
+    return File(reportsDir, "ktlint-$sourceSetName.${extension.reporter.fileExtension}")
 }


### PR DESCRIPTION
While the ktlint checkstyle reporter stream Strings in output file, it generates a corrupted XML after the first sourceSet run.

Fix-it by generating one file by sourceSet, with the following naming: `ktlint-${sourceSetName}.${extension.reporter.fileExtension}`