### PR TITLE
Fix report output is not closed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
  - Add configuration parameter `ignoreFailures` with default value to false
 ### Changed
- - Update default ktlint version to 0.9.2 
+ - Update default ktlint version to 0.9.2
+### Fixed
+ - Fixed report output is not closed after task run is finished (#25)
 
 ## [2.1.1] - 2017-08-15
 ### Changed

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
@@ -22,8 +22,10 @@ enum class ReporterType(val reporterName: String, val availableSinceVersion: Str
  */
 fun JavaExec.applyReporter(target: Project, extension: KtlintExtension) {
     if (isReportAvailable(extension.version, extension.reporter.availableSinceVersion)) {
+        val reportOutput = createReportOutputDir(target, extension).outputStream()
         this.args("--reporter=${extension.reporter.reporterName}")
-        this.standardOutput = createReportOutputDir(target, extension).outputStream()
+        this.standardOutput = reportOutput
+        doLast { reportOutput.close() }
     } else {
         target.logger.info("Reporter is not available in this ktlint version")
     }


### PR DESCRIPTION
Now plugin closes report output stream after task run is finished.

Fixes #25

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>