### PR TITLE
Fix report output is always opened since task is created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
-(Nothing yet)
+- Fixed report output is always opened since task is created
 
 ## [2.2.0] - 2017-10-05
 ### Added


### PR DESCRIPTION
I reported the problem that I cannot delete ktlint output file for `java.io.IOException` at #25 .
I thought the cause was that output stream was not closed.
However after fixed it, I still couldn't delete the file.

It seems that output stream is always opened.
I googled and found answers like [this](https://discuss.gradle.org/t/exec-standardoutput-to-file-in-builddir-but-no-builddir-yet/17913/2) or [this](https://stackoverflow.com/questions/13172215/gradle-output-file-not-up-to-date-if-parsed-from-standardoutput).
According to those, FileOutputStream should open in `doFirst` closure.