### PR TITLE
Fix wrong parsing of ktlint version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+### Fixed
+- Fixed plugin doesn't apply custom reporter for ktlint versions >0.10.x (#28)
 
 ## [2.2.1] - 2017-10-06
 ### Fixed

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
@@ -37,8 +37,8 @@ fun JavaExec.applyReporter(target: Project, extension: KtlintExtension) {
 }
 
 private fun isReportAvailable(version: String, availableSinceVersion: String): Boolean {
-    val versionsNumbers = version.split('.')
-    val reporterVersionNumbers = availableSinceVersion.split('.')
+    val versionsNumbers = version.split('.').map { it.toInt() }
+    val reporterVersionNumbers = availableSinceVersion.split('.').map { it.toInt() }
     return versionsNumbers[0] >= reporterVersionNumbers[0] &&
             versionsNumbers[1] >= reporterVersionNumbers[1] &&
             versionsNumbers[2] >= reporterVersionNumbers[2]


### PR DESCRIPTION
This prevents to use plugin with >0.10.x versions of ktlint.

Fixes #28 

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>