### PR TITLE
Different output file for every task (fix for #33)

### DIFF
--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -144,7 +144,7 @@ open class KtlintPlugin : Plugin<Project> {
             args(runArgs)
         }.apply {
             this.isIgnoreExitValue = extension.ignoreFailures
-            this.applyReporter(target, extension)
+            this.applyReporter(target, extension, sourceSetName)
         }
     }
 

--- a/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
+++ b/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Reporter.kt
@@ -21,11 +21,11 @@ enum class ReporterType(val reporterName: String, val availableSinceVersion: Str
 /**
  * Apply reporter to the task.
  */
-fun JavaExec.applyReporter(target: Project, extension: KtlintExtension) {
+fun JavaExec.applyReporter(target: Project, extension: KtlintExtension, sourceSetName: String) {
     if (isReportAvailable(extension.version, extension.reporter.availableSinceVersion)) {
         var reportOutput: FileOutputStream? = null
         doFirst {
-            reportOutput = createReportOutputDir(target, extension).outputStream().also {
+            reportOutput = createReportOutputDir(target, extension, sourceSetName).outputStream().also {
                 this.args("--reporter=${extension.reporter.reporterName}")
                 this.standardOutput = it
             }
@@ -44,8 +44,8 @@ private fun isReportAvailable(version: String, availableSinceVersion: String): B
             versionsNumbers[2] >= reporterVersionNumbers[2]
 }
 
-private fun createReportOutputDir(target: Project, extension: KtlintExtension): File {
-    val reportsDir = File(target.buildDir, "reports/ktlint")
+private fun createReportOutputDir(target: Project, extension: KtlintExtension, sourceSetName: String): File {
+    val reportsDir = File(target.buildDir, "reports")
     GFileUtils.mkdirs(reportsDir)
-    return File(reportsDir, "ktlint.${extension.reporter.fileExtension}")
+    return File(reportsDir, "ktlint-results-$sourceSetName.${extension.reporter.fileExtension}")
 }


### PR DESCRIPTION
Previously every task was using the same name as output file, so that if
you execute multiple tasks during the same build, every task was
overwriting the previous output.

This commit fix this issue providing a different name per each task. The
name is generated using the same source set name that is used for the
task name. This is also aligned to the output of Android Lint.

This fixes #33