### PR TITLE
Make dependency on Android SDK optional for samples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ triggers related tasks in subprojects.
 
 Import the [settings.gradle.kts](settings.gradle.kts) file into your IDE.
 
+To enable Android sample add `local.properties` file to project root folder with following content:
+```properties
+sdk.dir=<android-sdk-location>
+```
+
 #### Building
 
 `./gradlew build`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ triggers related tasks in subprojects.
 
 Import the [settings.gradle.kts](settings.gradle.kts) file into your IDE.
 
-To enable Android sample add `local.properties` file to project root folder with following content:
+To enable Android sample either define `ANDROID_HOME` environmental variable or
+add `local.properties` file to project root folder with following content:
 ```properties
 sdk.dir=<android-sdk-location>
 ```

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ pluginManagement {
 
 rootProject.name = "ktlint-gradle-samples"
 
-fun isAndroidSdkAvailable(): Boolean {
+fun isAndroidSdkInLocalPropertiesSet(): Boolean {
     val propertiesFile = file("local.properties")
     if (propertiesFile.exists()) {
         val properties = Properties()
@@ -26,6 +26,9 @@ fun isAndroidSdkAvailable(): Boolean {
 
     return false
 }
+
+fun isAndroidSdkVariableSet(): Boolean = System.getenv().containsKey("ANDROID_HOME")
+fun isAndroidSdkAvailable(): Boolean = isAndroidSdkVariableSet() || isAndroidSdkInLocalPropertiesSet()
 
 include("samples:kotlin-ks")
 include("samples:kotlin-gradle")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -14,8 +16,20 @@ pluginManagement {
 
 rootProject.name = "ktlint-gradle-samples"
 
+fun isAndroidSdkAvailable(): Boolean {
+    val propertiesFile = file("local.properties")
+    if (propertiesFile.exists()) {
+        val properties = Properties()
+        properties.load(propertiesFile.inputStream())
+        return properties.containsKey("sdk.dir")
+    }
+
+    return false
+}
+
 include("samples:kotlin-ks")
 include("samples:kotlin-gradle")
-include("samples:android-app")
-
+if (isAndroidSdkAvailable()) {
+    include("samples:android-app")
+}
 includeBuild("./plugin")


### PR DESCRIPTION
Fixes #57 

Signed-off-by: Yahor Berdnikau <egorr.berd@gmail.com>
