### PR TITLE
Fix running check task triggers execution of some android tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
  - Remove usage of deprecated Gradle features (#60)
 ### Fixed
- - ?
+ - Fix running check task also runs some android tasks (#63)
 
 ## [3.1.0] - 2018-3-18
 ## Added

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.gradle.plugin.KonanExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.tasks.KonanCompileTask
 import org.jlleitschuh.gradle.ktlint.reporter.applyReporters
+import java.io.File
 import kotlin.reflect.KClass
 
 const val VERIFICATION_GROUP = "Verification"
@@ -99,7 +100,13 @@ open class KtlintPlugin : Plugin<Project> {
                 }
 
                 variantManager?.variantScopes?.forEach {
-                    val kotlinSourceDir = target.files(it.variantData.javaSources)
+                    val sourceDirs = it.variantData.javaSources
+                            .fold(mutableListOf<File>()) { acc, configurableFileTree ->
+                                acc.add(configurableFileTree.dir)
+                                acc
+                            }
+                    // Don't use it.variantData.javaSources directly as it will trigger some android tasks execution
+                    val kotlinSourceDir = target.files(*sourceDirs.toTypedArray())
                     val runArgs = it.variantData.javaSources.map { "${it.dir.path}/**/*.kt" }.toMutableSet()
                     addAdditionalRunArgs(extension, runArgs)
 


### PR DESCRIPTION
Fixes #63.

Now running `ktlintCheck` tasks doesn't trigger some android tasks execution:
```
$ ./gradlew -m :samples:android-app:ktlintCheck
:samples:android-app:ktlintDebugAndroidTestCheck SKIPPED
:samples:android-app:ktlintDebugCheck SKIPPED
:samples:android-app:ktlintDebugUnitTestCheck SKIPPED
:samples:android-app:ktlintReleaseCheck SKIPPED
:samples:android-app:ktlintReleaseUnitTestCheck SKIPPED
:samples:android-app:ktlintCheck SKIPPED

BUILD SUCCESSFUL in 1s
```