### PR TITLE
Revert "Quote reporter output path"

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/reporter/Reporter.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/reporter/Reporter.kt
@@ -106,7 +106,7 @@ private inline fun checkReporterAvailable(
 private fun JavaExec.applyOutputReporter(reporter: ReporterType, target: Project, sourceSetName: String) {
     doFirst {
         val reporterOutput = createReportOutputFile(target, reporter.fileExtension, sourceSetName)
-        this.args("--reporter=${reporter.reporterName},output=\"${reporterOutput.absolutePath}\"")
+        this.args("--reporter=${reporter.reporterName},output=${reporterOutput.absolutePath}")
     }
 }
 


### PR DESCRIPTION
This reverts commit a5157885bd0382c05cde68ea3eb7b483d0d60939.

This commit leads that reported output created under following path:
```
<subproject-dir>/"/home/myuser/work/ktlint-gradle/samples/kotlin-gradle/build/reports/ktlint/ktlint-main.txt"
```

I've opened issue on ktlint side for better supporting spaces in output path: https://github.com/shyiko/ktlint/issues/177