### PR TITLE
Escape --reporter=.. to allow for spaces in report path

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/reporter/Reporter.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/reporter/Reporter.kt
@@ -106,7 +106,7 @@ private inline fun checkReporterAvailable(
 private fun JavaExec.applyOutputReporter(reporter: ReporterType, target: Project, sourceSetName: String) {
     doFirst {
         val reporterOutput = createReportOutputFile(target, reporter.fileExtension, sourceSetName)
-        this.args("--reporter=${reporter.reporterName},output=${reporterOutput.absolutePath}")
+        this.args("\"--reporter=${reporter.reporterName},output=${reporterOutput.absolutePath}\"")
     }
 }
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -17,7 +17,7 @@ abstract class AbstractPluginTest {
     val temporaryFolder = TemporaryFolder()
 
     val projectRoot: File
-        get() = temporaryFolder.root.resolve("plugin-test").apply { mkdirs() }
+        get() = temporaryFolder.root.resolve("plugin test").apply { mkdirs() }
 
     protected
     fun buildscriptBlockWithUnderTestPlugin() =


### PR DESCRIPTION
Follow up to #68 with a better approach, including tests.