### PR TITLE
Use relative for input file path sensitivity

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -17,6 +17,7 @@ import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.Convention
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.StopExecutionException
 import org.jetbrains.kotlin.gradle.plugin.KonanArtifactContainer
 import org.jetbrains.kotlin.gradle.plugin.KonanExtension
@@ -221,6 +222,8 @@ open class KtlintPlugin : Plugin<Project> {
             main = "com.github.shyiko.ktlint.Main"
             classpath = ktLintConfig
             inputs.files(kotlinSourceSet)
+                    .withPropertyName("source")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
             args(runArgs)
         }.apply {
             this.isIgnoreExitValue = extension.ignoreFailures


### PR DESCRIPTION
This allows enabling caching for the check task. Without adding a path
sensitivity, caching the check task does not make much sense, since it
would require using the same absolute path to the source files for all
workspaces which want to get cache hits.

See https://guides.gradle.org/using-build-cache/#relocatability.