### PR TITLE
New release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased [3.4.0-SNAPSHOT]
 ### Added
+ - Add support for providing custom rulesets (#71)
  - Also check `*.kts` files in Kotlin source directories
  - Use a cacheable task for the KtLint check
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
   - KtLint versions prior to 0.10.0 are not supported anymore
   - Gradle versions prior to 4.3 are not supported anymore
+  - Deprecated ReporterType typealias
+  - Deprecated reporter field from extension
 
 ## [3.3.0] - 2018-4-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased [3.4.0-SNAPSHOT]
+## [4.0.0] - 2018-5-15
 ### Added
  - Add support for providing custom rulesets (#71)
  - Also check `*.kts` files in Kotlin source directories
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
   - Update Kotlin to 1.2.41 version
   - Update Gradle wrapper to 4.7 version
-### Fixed
+  - Changed default KtLint version to `0.23.1`
 ### Removed
   - KtLint versions prior to 0.10.0 are not supported anymore
   - Gradle versions prior to 4.3 are not supported anymore

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ The assumption being that you would not want to lint code you weren't compiling.
 This plugin was written using the new API available for gradle script kotlin builds.
 This API is available in new versions of gradle.
 
-This plugin has only been tested with gradle `3.5` and should work with versions `3.5+`.
+Minimal supported Gradle version: `4.3`
 
-If you find this plugin works with older versions feel free to update this readme to reflect this.
-
+Minimal supported [ktlint](https://github.com/shyiko/ktlint) version: `0.10.0`
 
 ## How to use
 
@@ -29,7 +28,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.3.0"
+    classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:4.0.0"
   }
 }
 
@@ -39,7 +38,7 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 Build script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
 ```groovy
 plugins {
-  id "org.jlleitschuh.gradle.ktlint" version "3.3.0"
+  id "org.jlleitschuh.gradle.ktlint" version "4.0.0"
 }
 ```
 
@@ -71,6 +70,10 @@ ktlint {
 }
 ```
 
+## Samples
+
+Check [samples](samples/) folder that provides examples how-to apply plugin.
+
 ## Tasks Added
 
 This plugin adds two tasks to every source set: `ktlint[source set name]Check` and `ktlint[source set name]Format`.
@@ -95,11 +98,9 @@ sdk.dir=<android-sdk-location>
 
 #### Building
 
-`./gradlew build`
+Building the plugin: `./plugin/gradlew build`
 
-### Future Development
-
-Add support for linting `*.kts` for gradle script kotlin builds.
+Running current plugin snapshot check on sample projects: `./gradlew ktlintCheck`
 
 ## Links
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "org.jlleitschuh.gradle"
-version = "3.4.0-SNAPSHOT"
+version = "4.0.0"
 
 repositories {
     jcenter()

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -1,7 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
-@Deprecated("Moved to org.jlleitschuh.gradle.ktlint.reporter package")
-typealias ReporterType = org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 /**
  * Extension class for configuring the [KtlintPlugin].
@@ -49,15 +48,4 @@ open class KtlintExtension {
      * Default is plain.
      */
     var reporters: Array<ReporterType> = arrayOf(ReporterType.PLAIN)
-
-    /**
-     * Report output format.
-     *
-     * Available values: plain, plain_group_by_file, checkstyle, json.
-     *
-     * Default is none, please, mirgrate to [reporters].
-     */
-    @Deprecated(message = "Ktlint introduced multi output support since 0.11.1 version",
-            replaceWith = ReplaceWith("reporters = arrayOf()", "reporter"))
-    var reporter: ReporterType? = null
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -238,7 +238,7 @@ open class KtlintPlugin : Plugin<Project> {
             reports.forEach { _, report ->
                 report.enabled.set(target.provider {
                     val reporterType = report.reporterType
-                    reporterAvailable(extension.version, reporterType) && (extension.reporters.contains(reporterType) || extension.reporter == reporterType)
+                    reporterAvailable(extension.version, reporterType) && extension.reporters.contains(reporterType)
                 })
                 report.outputFile.set(target.layout.buildDirectory.file(target.provider {
                     "reports/ktlint/ktlint-$sourceSetName.${report.reporterType.fileExtension}"


### PR DESCRIPTION
New significant release 4.0.0 that has breaking changes.

Additionally:
- Removed deprecated `ReporterType` typealias
- Updated default KtLint version to latest
- Updated changelog with introducing custom rulesets option