### PR TITLE
WIP: Use android docker image on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
+sudo: required
+
 language: android
-jdk:
-  - oraclejdk8
-install:
-  - yes | sdkmanager --verbose "build-tools;26.0.2"
-  - yes | sdkmanager --verbose "platform-tools"
-  - yes | sdkmanager --verbose "tools"
-  - yes | sdkmanager --verbose "platforms;android-27"
-  - yes | sdkmanager --verbose "extras;android;m2repository"
+
+services:
+  - docker
+
+before_install:
+  - docker pull circleci/android:api-27-alpha
+  - docker run circleci/android:api-27-alpha --name build -w /build -v `pwd`:/build /bin/bash
 
 script:
-  - ./plugin/gradlew -p ./plugin build --no-daemon
-  - ./plugin/gradlew -p ./plugin ktlintCheck --no-daemon
-  - ./gradlew ktlintCheck --no-daemon
+  - docker exec build plugin/gradlew -p plugin build --no-daemon
+  - docker exec build plugin/gradlew -p plugin ktlintCheck --no-daemon
+  - docker exec build gradlew ktlintCheck --no-daemon
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
This should improve build time, as this image will already contain
all required android build tools.