### PR TITLE
Configure publishing via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,21 @@ script:
   - ./plugin/gradlew -p ./plugin build --no-daemon
   - ./plugin/gradlew -p ./plugin ktlintCheck --no-daemon
   - ./gradlew ktlintCheck --no-daemon
+  - if [ -n "$TRAVIS_TAG" ]; then ./plugin/gradlew publishPlugins --no-daemon; fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+env:
+  matrix:
+  # GRADLE_PUBLISH_KEY
+  - secure: EKhQ30ulNgANZex5MKJh9ZcOT5i1515JugO8TXnZ7cxRIpaKETKOY9kAyrvLBM/knNVc4GPkbbz3Q1r/lK7O25+dxprKtL3QcoWtoCGbfimQFMfX45F+NECkTcXouaOQYoC8H62f8S0UfTO6TKhGe7mdUrlrQ8cM/ukGrpO4ZYs1QzxlLLdvzbR9SbM9y/LYC6ZgtNLCJ1vAipZ3MvuuADrP4Q6VwzVLATp2vlVbCofxoRzUJ9j0seghgI0dFiDSUM4CkGe71Nuk9xxTAt1RmxbWHaW1PPwID5iwhm2rAWd56liOvqOw64cQWiaUlb7vZShcCO1n7PCilSafQTAM67Ag9CKHiHTdqqkB1eYCvFKDWVlk1MG9/ECBUoGi3RQ6Mv1VS4+Ev8v5SSaDnrNbDqrwVobV3Sjo5nsC0pAtOnac5FogD6VyIuc8UuWEMJoBAPRXPj/uS5KXC6dqBXyHo40NISiVNOxO7afJsVXELZo8H1+0TD9HzRfSc7M6KP8rCIQ79PlAiuHTnO8mjYYhqcDzr6NlGG6AGHMENh/U1etZk/URwOwwvO19+WRZq1470sfKcDOmupdpp026iP3j2JA+fdMKBlCWwouoUioibBe+ljoxB1vuBEaNXRUj4yGUzlQTBxY8cEXuFgcXQlNf6jEW4CHRt2GRq01s2dO/L08=
+  # GRADLE_PUBLISH_SECRET
+  - secure: PlwBtj9pwjpl/0j7lgRzwwBEjC4ZCcSHSTvJkNGQa97pnHopaRzNohWdEVNp16BKXxkaOAmxF1dQ1e/NxZ4TXQVe83ZKgg1NrE/ANTKqBRXfj/dsYKdeFCN117ph+FiL2soKplinUPMlS96PPM519iQ2B58EKzxyuVlDpArvYgOVtr2fZ5K6bBJQ3qyExiw2ocwCqmgMVwQPVwV8JU55HapzSeV5XyLu4RfcO7cZho4n4oxTGZTCiTX41gbfOIYYkFWFlXiluKs4zDAi3qlCZ67HxLKXcsfLk2qbeQlscH5cmfbqi5k/hpPWcFr8qzdolLoXj/ddVkb1AQ6LicI758Chcnl3LoWPaR1DmWwG8TGxxJsHBDmPw7GmuzrU956zbpPETI9HmCV2eeS87O+pJvnEZk6GJ3DwJau3tn+xHl46OV88R/gOhTJnt8yrMD+iSlHo4WtN/U0GA+8mPa6FagtCdYXgy+qLTrdS1LCcjOSy64IxTyboI+GoPsXe3ixH7gwi01v4+YqVeJN6waqkVkjSbfc7EZtKhdjhfyKn4Fpryqymnz3+WzuelFVjzWtT6PkIKBrUPjND/WY7s83wOTl0rDExjAyukSS6mM8ZQlVg6LzXvG+8mWB/F48U1qKRtSQesoHa1etDyY6rL09vD4kZrenPNqpgt/WS5Srs/Ac=
+

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -51,6 +51,29 @@ publishing {
     }
 }
 
+/**
+ * Configures the publishing environment for publishing with Travis CI.
+ * All you need to do is push a tagged commit to github and Travis CI will automatically publish a
+ * release of the plugin using the current [Project.getVersion].
+ */
+fun setupPublishingEnvironment() {
+    val keyEnvironmentVariable = "GRADLE_PUBLISH_KEY"
+    val secretEnvironmentVariable = "GRADLE_PUBLISH_SECRET"
+
+    val keyProperty = "gradle.publish.key"
+    val secretProperty = "gradle.publish.secret"
+
+    if (System.getProperty(keyProperty) == null || System.getProperty(secretProperty) == null) {
+        logger
+            .info("`$keyProperty` or `$secretProperty` were not set. Attempting to configure from environment variables")
+
+        System.setProperty(keyProperty, System.getProperty(keyEnvironmentVariable))
+        System.setProperty(secretProperty, System.getProperty(secretEnvironmentVariable))
+    }
+}
+
+setupPublishingEnvironment()
+
 gradlePlugin {
     (plugins) {
         "ktlintPlugin" {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -67,8 +67,14 @@ fun setupPublishingEnvironment() {
         logger
             .info("`$keyProperty` or `$secretProperty` were not set. Attempting to configure from environment variables")
 
-        System.setProperty(keyProperty, System.getProperty(keyEnvironmentVariable))
-        System.setProperty(secretProperty, System.getProperty(secretEnvironmentVariable))
+        val key: String? = System.getProperty(keyEnvironmentVariable)
+        val secret: String? = System.getProperty(secretEnvironmentVariable)
+        if (key != null && secret != null) {
+            System.setProperty(keyProperty, key)
+            System.setProperty(secretProperty, secret)
+        } else {
+            logger.debug("key or secret was null")
+        }
     }
 }
 


### PR DESCRIPTION
Once a release commit has been pushed, you can simply checkout the `master` branch and run.
```
git tag v[whatever version]
```
From there run `git push --tags` and travis CI will publish the release for you.

Note: Gradle still reads the version from the `version` variable, not from git.
It's expected that these two versions are the same when a release is performed.

Also, I haven't been able to test this yet as it requires performing a release.