### PR TITLE
Fix .editorconfig file change doesn't reset check task state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
   - ?
 ### Fixed
-  - ?
+  - `.editorconfig` file change doesn't reset `UP-TO-DATE` `ktlintCheck` task state (#106)
 
 
 ## [5.0.0] - 2018-8-6

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
@@ -44,10 +44,10 @@ open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : Defau
         }
     }
 
-    @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
     internal val editorConfigFiles: FileCollection = getEditorConfigFiles(project)
+
     @get:Input
     val verbose: Property<Boolean> = objectFactory.booleanProperty()
     @get:Input

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
@@ -4,6 +4,7 @@ import net.swiftzer.semver.SemVer
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -25,6 +26,8 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import java.io.File
 import javax.inject.Inject
 
+private const val EDITORCONGIG_FILE_NAME = ".editorconfig"
+
 @CacheableTask
 open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : DefaultTask() {
 
@@ -43,6 +46,11 @@ open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : Defau
         }
     }
 
+    @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputFiles
+    internal val editorConfigFiles: FileCollection = project.rootProject.files(EDITORCONGIG_FILE_NAME)
+        .plus(project.files(EDITORCONGIG_FILE_NAME))
     @get:Input
     val verbose: Property<Boolean> = objectFactory.booleanProperty()
     @get:Input

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
@@ -26,8 +26,6 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import java.io.File
 import javax.inject.Inject
 
-private const val EDITORCONGIG_FILE_NAME = ".editorconfig"
-
 @CacheableTask
 open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : DefaultTask() {
 
@@ -49,8 +47,7 @@ open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : Defau
     @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
-    internal val editorConfigFiles: FileCollection = project.rootProject.files(EDITORCONGIG_FILE_NAME)
-        .plus(project.files(EDITORCONGIG_FILE_NAME))
+    internal val editorConfigFiles: FileCollection = getEditorConfigFiles(project)
     @get:Input
     val verbose: Property<Boolean> = objectFactory.booleanProperty()
     @get:Input

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -3,8 +3,10 @@ package org.jlleitschuh.gradle.ktlint
 import net.swiftzer.semver.SemVer
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.HelpTasksPlugin
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import java.nio.file.Path
 
 internal fun createConfiguration(target: Project, extension: KtlintExtension) =
     target.configurations.maybeCreate("ktlint").apply {
@@ -20,6 +22,56 @@ internal fun createConfiguration(target: Project, extension: KtlintExtension) =
 
 internal inline fun <reified T : Task> Project.taskHelper(name: String, noinline configuration: T.() -> Unit): T {
     return this.tasks.create(name, T::class.java, configuration)
+}
+
+internal const val EDITOR_CONFIG_FILE_NAME = ".editorconfig"
+
+internal fun getEditorConfigFiles(currentProject: Project): FileCollection {
+    return searchEditorConfigFiles(
+        currentProject,
+        currentProject.projectDir.toPath(),
+        currentProject.files()
+    )
+}
+
+private tailrec fun searchEditorConfigFiles(
+    project: Project,
+    projectPath: Path,
+    fileCollection: FileCollection
+): FileCollection {
+    val editorConfigFC = projectPath.resolve(EDITOR_CONFIG_FILE_NAME)
+    val outputCollection = if (editorConfigFC != null) {
+        fileCollection.plus(project.files(editorConfigFC))
+    } else {
+        fileCollection
+    }
+
+    val parentDir = projectPath.parent
+    return if (parentDir != null &&
+        parentDir != project.rootDir.toPath() &&
+        !editorConfigFC.isRootEditorConfig()) {
+        searchEditorConfigFiles(project, parentDir, outputCollection)
+    } else {
+        outputCollection
+    }
+}
+
+private val editorConfigRootRegex = "^root\\s?=\\s?true\\n".toRegex()
+
+private fun Path.isRootEditorConfig(): Boolean {
+    val asFile = toFile()
+    if (!asFile.exists() || !asFile.canRead()) return false
+
+    val reader = asFile.bufferedReader()
+    var fileLine = reader.readLine()
+    while (fileLine != null) {
+        if (fileLine.contains(editorConfigRootRegex)) {
+            return true
+        }
+        fileLine = reader.readLine()
+    }
+
+    return false
 }
 
 /**

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -73,6 +73,23 @@ abstract class AbstractPluginTest {
         sourceFile.writeText(contents)
     }
 
+    protected fun File.createEditorconfigFile(
+        maxLineLength: Int = 120
+    ) = createSourceFile(".editorconfig", """
+        [*.{kt,kts}]
+        max_line_length=$maxLineLength
+    """.trimIndent())
+
+    protected fun File.modifyEditorconfigFile(
+        maxLineLength: Int
+    ) {
+        val editorconfigFile = resolve(".editorconfig")
+        if (editorconfigFile.exists()) {
+            editorconfigFile.delete()
+        }
+        createEditorconfigFile(maxLineLength)
+    }
+
     fun File.buildFile() = resolve("build.gradle")
     fun File.settingsFile() = resolve("settings.gradle")
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -116,6 +116,34 @@ class KtlintPluginTest : AbstractPluginTest() {
     }
 
     @Test
+    fun `Check task should be up_to_date if editorconfig content not changed`() {
+        projectRoot.withCleanSources()
+        projectRoot.createEditorconfigFile()
+
+        build("ktlintCheck").apply {
+            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+        build("ktlintCheck").apply {
+            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
+        }
+    }
+
+    @Test
+    fun `Check task should rerun if editorconfig content changed`() {
+        projectRoot.withCleanSources()
+        projectRoot.createEditorconfigFile()
+
+        build("ktlintCheck").apply {
+            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+
+        projectRoot.modifyEditorconfigFile(100)
+        build("ktlintCheck").apply {
+            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+    }
+
+    @Test
     fun `check task is relocatable`() {
         val originalLocation = temporaryFolder.root.resolve("original")
         val relocatedLocation = temporaryFolder.root.resolve("relocated")


### PR DESCRIPTION
This PR fixes issue that `ktlintCheck` task ignores `.editorconfig` file changes.

For now task assumes that `.editorconfig` file will be either in root project folder or in current project folder. If somebody will need more advanced logic - new issue should be created and this problem will be addressed in a separate PR.

Fixes #106.