### PR TITLE
Remove usages of afterEvaluate {}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.2.0] - Unreleased
+## [6.0.0] - Unreleased
 ### Added
-  - ?
+  - Separate KtlintFormatTask task (#111)
 ### Changed
-  - ?
+  - `ktlintApplyToIdea` task is always added, though it will fail on
+  ktlint versions less then `0.22.0`
+  - Plugin extension now uses Gradle properties for configuration
+  - `ktlint.reporters` extension property has to use imported `ReporterType`
+  in groovy Gradle build scripts.
+  - reporters output file name changed to be the same as task name. For example for `PLAIN`
+  it will be `ktlintMainCheck.txt`.
+  - format tasks now are also generate reports. For example: `ktlintMainFormat.txt`.
 ### Removed
   - Usages of `afterEvaluate {}` in plugin and sample projects (#122)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
   - ?
 ### Removed
-  - ?
+  - Usages of `afterEvaluate {}` in plugin and sample projects (#122)
 ### Fixed
   - ?
 

--- a/README.md
+++ b/README.md
@@ -139,18 +139,39 @@ The version of ktlint used by default _may change_ between patch versions of thi
 If you don't want to inherit these changes then make sure you lock your version here.
 
 ```groovy
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
 ktlint {
-    version = ""
+    version = "0.22.0"
     debug = true
     verbose = true
     android = false
     outputToConsole = true
-    reporters = ["PLAIN", "CHECKSTYLE"]
+    reporters = [ReporterType.PLAIN, ReporterType.CHECKSTYLE]
     ignoreFailures = true
     ruleSets = [
         "/path/to/custom/rulseset.jar",
         "com.github.username:rulseset:master-SNAPSHOT"
     ]
+}
+```
+
+or in kotlin script:
+```kotlin
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
+ktlint {
+    version.set("0.22.0")
+    debug.set(true)
+    verbose.set(true)
+    android.set(false)
+    outputToConsole.set(true)
+    reporters.set(setOf(ReporterType.PLAIN, ReporterType.CHECKSTYLE))
+    ignoreFailures.set(true)
+    ruleSets.set(listOf(
+        "/path/to/custom/rulseset.jar",
+        "com.github.username:rulseset:master-SNAPSHOT"
+    ))
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
         classpath("org.jlleitschuh.gradle:ktlint-gradle:+")
     }
 }
+
 plugins {
     kotlin("jvm") version SamplesVersions.kotlin apply false
     id("com.android.application") version SamplesVersions.androidPlugin apply false
@@ -20,6 +21,10 @@ allprojects {
         jcenter()
         google()
     }
+}
+
+apply {
+    plugin("org.jlleitschuh.gradle.ktlint")
 }
 
 task<Wrapper>("wrapper") {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 
     testImplementation(gradleTestKit())
     testImplementation("junit:junit:${PluginVersions.junit}")
+    testImplementation(kotlin("reflect"))
 }
 
 publishing {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
@@ -44,7 +44,7 @@ open class KtlintApplyToIdeaTask @Inject constructor(
             }
             // -y here to auto-overwrite existing IDEA code style
             it.args("-y")
-            if (android.get()) {
+            if (android.get() && ktlintVersion.isAndroidFlagAvailable()) {
                 it.args("--android")
             }
         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
@@ -2,12 +2,12 @@ package org.jlleitschuh.gradle.ktlint
 
 import net.swiftzer.semver.SemVer
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
@@ -31,7 +31,7 @@ open class KtlintApplyToIdeaTask @Inject constructor(
     fun generate() {
         if (!globally.get() && !isApplyToIdeaPerProjectAvailable()) {
             logger.error("Apply per project in only available from ktlint 0.22.0")
-            throw StopExecutionException("Apply per project in only available from ktlint 0.22.0")
+            throw GradleException("Apply per project in only available from ktlint 0.22.0")
         }
 
         project.javaexec {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
@@ -1,11 +1,13 @@
 package org.jlleitschuh.gradle.ktlint
 
+import net.swiftzer.semver.SemVer
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
@@ -17,13 +19,21 @@ open class KtlintApplyToIdeaTask @Inject constructor(
     val classpath: ConfigurableFileCollection = project.files()
 
     @get:Input
-    val android: Property<Boolean> = objectFactory.booleanProperty()
+    val android: Property<Boolean> = objectFactory.property()
 
     @get:Input
-    val globally: Property<Boolean> = objectFactory.booleanProperty()
+    val globally: Property<Boolean> = objectFactory.property()
+
+    @get:Input
+    val ktlintVersion: Property<String> = objectFactory.property()
 
     @TaskAction
     fun generate() {
+        if (!globally.get() && !isApplyToIdeaPerProjectAvailable()) {
+            logger.error("Apply per project in only available from ktlint 0.22.0")
+            throw StopExecutionException("Apply per project in only available from ktlint 0.22.0")
+        }
+
         project.javaexec {
             it.classpath = classpath
             it.main = "com.github.shyiko.ktlint.Main"
@@ -40,6 +50,11 @@ open class KtlintApplyToIdeaTask @Inject constructor(
         }
     }
 
-    private fun ObjectFactory.booleanProperty() =
-            property(Boolean::class.javaObjectType)
+    /**
+     * Checks if apply code style to IDEA IDE per project is available.
+     *
+     * Available since KtLint version `0.22.0`.
+     */
+    private fun isApplyToIdeaPerProjectAvailable() =
+        SemVer.parse(ktlintVersion.get()) >= SemVer(0, 22, 0)
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
@@ -10,6 +10,6 @@ open class KtlintBasePlugin : Plugin<Project> {
     internal lateinit var extension: KtlintExtension
 
     override fun apply(target: Project) {
-        extension = target.extensions.create("ktlint", KtlintExtension::class.java)
+        extension = target.extensions.create("ktlint", KtlintExtension::class.java, target)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
@@ -10,6 +10,10 @@ open class KtlintBasePlugin : Plugin<Project> {
     internal lateinit var extension: KtlintExtension
 
     override fun apply(target: Project) {
-        extension = target.extensions.create("ktlint", KtlintExtension::class.java, target)
+        extension = target.extensions.create(
+            "ktlint",
+            KtlintExtension::class.java,
+            target.objects
+        )
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheck.kt
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.jlleitschuh.gradle.ktlint.reporter.KtlintReport
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
-import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
@@ -49,21 +48,23 @@ open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : Defau
     internal val editorConfigFiles: FileCollection = getEditorConfigFiles(project)
 
     @get:Input
-    val verbose: Property<Boolean> = objectFactory.booleanProperty()
+    val ktlintVersion: Property<String> = objectFactory.property()
+    @get:Input
+    val verbose: Property<Boolean> = objectFactory.property()
     @get:Input
     val ruleSets: ListProperty<String> = objectFactory.listProperty(String::class.java)
     @get:Input
-    val debug: Property<Boolean> = objectFactory.booleanProperty()
+    val debug: Property<Boolean> = objectFactory.property()
     @get:Input
-    val android: Property<Boolean> = objectFactory.booleanProperty()
+    val android: Property<Boolean> = objectFactory.property()
     @get:Input
-    val ignoreFailures: Property<Boolean> = objectFactory.booleanProperty()
+    val ignoreFailures: Property<Boolean> = objectFactory.property()
     @get:Console
-    val outputToConsole: Property<Boolean> = objectFactory.booleanProperty()
+    val outputToConsole: Property<Boolean> = objectFactory.property()
 
     @get:Internal
     val reports: Map<ReporterType, KtlintReport> = ReporterType.values().map {
-        it to KtlintReport(objectFactory.booleanProperty().apply { set(false) }, it, newOutputFile())
+        it to KtlintReport(objectFactory.property<Boolean>().apply { set(false) }, it, newOutputFile())
     }.toMap()
 
     @get:Internal
@@ -73,67 +74,52 @@ open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : Defau
     @TaskAction
     fun lint() {
         val reportsToProcess = enabledReports.values
-        val ktlintVersion = determineKtlintVersion(classpath)
-        ktlintVersion?.let {
-            it.checkMinimalSupportedKtlintVersion()
-            it.checkOutputPathsWithSpacesSupported(reportsToProcess)
-        }
-        project.javaexec {
-            it.classpath = classpath
-            it.main = "com.github.shyiko.ktlint.Main"
-            it.args(sourceDirectories.flatMap { dir -> KOTLIN_EXTENSIONS.map { extension -> "${dir.path}/**/*.$extension" } })
+        checkMinimalSupportedKtlintVersion()
+        checkOutputPathsWithSpacesSupported(reportsToProcess)
+
+        project.javaexec { javaExecSpec ->
+            javaExecSpec.classpath = classpath
+            javaExecSpec.main = "com.github.shyiko.ktlint.Main"
+            javaExecSpec.args(sourceDirectories.flatMap { dir ->
+                KOTLIN_EXTENSIONS.map { extension ->
+                    "${dir.path}/**/*.$extension"
+                }
+            })
             if (verbose.get()) {
-                it.args("--verbose")
+                javaExecSpec.args("--verbose")
             }
             if (debug.get()) {
-                it.args("--debug")
+                javaExecSpec.args("--debug")
             }
-            if (android.get()) {
-                it.args("--android")
+            if (android.get() && ktlintVersion.isAndroidFlagAvailable()) {
+                javaExecSpec.args("--android")
             }
             if (outputToConsole.get()) {
-                it.args("--reporter=plain")
+                javaExecSpec.args("--reporter=plain")
             }
-            it.args(ruleSets.get().map { "--ruleset=$it" })
-            it.isIgnoreExitValue = ignoreFailures.get()
-            it.args(reportsToProcess.map { it.asArgument() })
+            javaExecSpec.args(ruleSets.get().map { "--ruleset=$it" })
+            javaExecSpec.isIgnoreExitValue = ignoreFailures.get()
+            javaExecSpec.args(reportsToProcess.map { it.asArgument() })
         }
     }
 
-    private
-    fun SemVer.checkMinimalSupportedKtlintVersion() {
-            if (this < SemVer(0, 10, 0)) {
-                throw GradleException("Ktlint versions less than 0.10.0 are not supported. Detected Ktlint version: $this.")
-            }
+    private fun checkMinimalSupportedKtlintVersion() {
+        if (SemVer.parse(ktlintVersion.get()) < SemVer(0, 10, 0)) {
+            throw GradleException("Ktlint versions less than 0.10.0 are not supported. Detected Ktlint version: $this.")
+        }
     }
 
-    private
-    fun SemVer.checkOutputPathsWithSpacesSupported(reportsToProcess: Collection<KtlintReport>) {
-        if (this < SemVer(0, 20, 0)) {
+    private fun checkOutputPathsWithSpacesSupported(reportsToProcess: Collection<KtlintReport>) {
+        if (SemVer.parse(ktlintVersion.get()) < SemVer(0, 20, 0)) {
             reportsToProcess.forEach {
                 val reportOutputPath = it.outputFile.get().asFile.absolutePath
                 if (reportOutputPath.contains(" ")) {
                     throw GradleException(
-                            "The output path passed `$reportOutputPath` contains spaces. Ktlint versions less than 0.20.0 do not support this.")
+                        "The output path passed `$reportOutputPath` contains spaces. Ktlint versions less than 0.20.0 do not support this.")
                 }
             }
         }
     }
-
-    private
-    fun determineKtlintVersion(ktlintClasspath: Iterable<File>): SemVer? {
-        val ktlintJarRegex = "ktlint-(\\d+.*)\\.jar".toRegex()
-        val ktlintJarName = ktlintClasspath.find { ktlintJarRegex.matches(it.name) }?.name
-        val version = ktlintJarName?.let {
-            val versionString = ktlintJarRegex.matchEntire(it)?.groups?.get(1)?.value ?: return null
-            try { SemVer.parse(versionString) } catch (e: IllegalArgumentException) { null }
-        }
-        return version
-    }
-
-    private
-    fun ObjectFactory.booleanProperty() =
-            property(Boolean::class.javaObjectType)
 
     @get:OutputFiles
     val reportOutputFiles: Map<ReporterType, RegularFileProperty>

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -120,7 +120,7 @@ open class KtlintCheckTask @Inject constructor(
 
     private fun checkMinimalSupportedKtlintVersion() {
         if (SemVer.parse(ktlintVersion.get()) < SemVer(0, 10, 0)) {
-            throw GradleException("Ktlint versions less than 0.10.0 are not supported." +
+            throw GradleException("Ktlint versions less than 0.10.0 are not supported. " +
                 "Detected Ktlint version: ${ktlintVersion.get()}.")
         }
     }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -120,7 +120,8 @@ open class KtlintCheckTask @Inject constructor(
 
     private fun checkMinimalSupportedKtlintVersion() {
         if (SemVer.parse(ktlintVersion.get()) < SemVer(0, 10, 0)) {
-            throw GradleException("Ktlint versions less than 0.10.0 are not supported. Detected Ktlint version: $this.")
+            throw GradleException("Ktlint versions less than 0.10.0 are not supported." +
+                "Detected Ktlint version: ${ktlintVersion.get()}.")
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -33,15 +33,15 @@ open class KtlintCheckTask @Inject constructor(
 ) : DefaultTask() {
 
     @get:Classpath
-    val classpath: ConfigurableFileCollection = project.files()
+    internal val classpath: ConfigurableFileCollection = project.files()
 
     @get:Internal
-    val sourceDirectories: ConfigurableFileCollection = project.files()
+    internal val sourceDirectories: ConfigurableFileCollection = project.files()
 
     @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
-    val sources: FileTree = sourceDirectories.asFileTree.matching { filterable ->
+    internal val sources: FileTree = sourceDirectories.asFileTree.matching { filterable ->
         KOTLIN_EXTENSIONS.forEach {
             filterable.include("**/*.$it")
         }
@@ -52,24 +52,24 @@ open class KtlintCheckTask @Inject constructor(
     internal val editorConfigFiles: FileCollection = getEditorConfigFiles(project)
 
     @get:Input
-    val ktlintVersion: Property<String> = objectFactory.property()
+    internal val ktlintVersion: Property<String> = objectFactory.property()
     @get:Input
-    val verbose: Property<Boolean> = objectFactory.property()
+    internal val verbose: Property<Boolean> = objectFactory.property()
     @get:Input
-    val ruleSets: ListProperty<String> = objectFactory.listProperty(String::class.java)
+    internal val ruleSets: ListProperty<String> = objectFactory.listProperty(String::class.java)
     @get:Input
-    val debug: Property<Boolean> = objectFactory.property()
+    internal val debug: Property<Boolean> = objectFactory.property()
     @get:Input
-    val android: Property<Boolean> = objectFactory.property()
+    internal val android: Property<Boolean> = objectFactory.property()
     @get:Input
-    val ignoreFailures: Property<Boolean> = objectFactory.property()
+    internal val ignoreFailures: Property<Boolean> = objectFactory.property()
     @get:Internal
-    val reporters: SetProperty<ReporterType> = objectFactory.setProperty()
+    internal val reporters: SetProperty<ReporterType> = objectFactory.setProperty()
     @get:Console
-    val outputToConsole: Property<Boolean> = objectFactory.property()
+    internal val outputToConsole: Property<Boolean> = objectFactory.property()
 
     @get:Internal
-    val enabledReports
+    internal val enabledReports
         get() = reporters.get()
             .map {
                 KtlintReport(

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -26,7 +26,7 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import javax.inject.Inject
 
 @CacheableTask
-open class KtlintCheck @Inject constructor(objectFactory: ObjectFactory) : DefaultTask() {
+open class KtlintCheckTask @Inject constructor(objectFactory: ObjectFactory) : DefaultTask() {
 
     @get:Classpath
     val classpath: ConfigurableFileCollection = project.files()

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -13,31 +13,31 @@ open class KtlintExtension(
     /**
      * The version of ktlint to use.
      */
-    val version: Property<String> = objectFactory.property()
+    val version: Property<String> = objectFactory.property { set("0.27.0") }
 
     /**
      * Enable verbose mode.
      */
-    val verbose: Property<Boolean> = objectFactory.property()
+    val verbose: Property<Boolean> = objectFactory.property { set(false) }
     /**
      * Enable debug mode.
      */
-    val debug: Property<Boolean> = objectFactory.property()
+    val debug: Property<Boolean> = objectFactory.property { set(false) }
     /**
      * Enable android mode.
      */
-    val android: Property<Boolean> = objectFactory.property()
+    val android: Property<Boolean> = objectFactory.property { set(false) }
     /**
      * Enable console output mode.
      */
-    val outputToConsole: Property<Boolean> = objectFactory.property()
+    val outputToConsole: Property<Boolean> = objectFactory.property { set(true) }
     /**
      * Whether or not to allow the build to continue if there are warnings;
      * defaults to {@code false}, as for any other static code analysis tool.
      * <p>
      * Example: `ignoreFailures = true`
      */
-    val ignoreFailures: Property<Boolean> = objectFactory.property()
+    val ignoreFailures: Property<Boolean> = objectFactory.property { set(false) }
     /**
      * The ruleset(s) of ktlint to use.
      */
@@ -53,13 +53,4 @@ open class KtlintExtension(
      * Default is plain.
      */
     var reporters: Array<ReporterType> = arrayOf(ReporterType.PLAIN)
-
-    init {
-        version.set("0.27.0")
-        android.set(false)
-        verbose.set(false)
-        debug.set(false)
-        outputToConsole.set(true)
-        ignoreFailures.set(false)
-    }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -18,7 +18,7 @@ open class KtlintExtension(
     /**
      * Enable verbose mode.
      */
-    var verbose = false
+    val verbose: Property<Boolean> = objectFactory.property()
     /**
      * Enable debug mode.
      */
@@ -57,5 +57,6 @@ open class KtlintExtension(
     init {
         version.set("0.27.0")
         android.set(false)
+        verbose.set(false)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -1,6 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
@@ -8,12 +8,12 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
  * Extension class for configuring the [KtlintPlugin].
  */
 open class KtlintExtension(
-    project: Project
+    objectFactory: ObjectFactory
 ) {
     /**
      * The version of ktlint to use.
      */
-    val version: Property<String> = project.objects.property()
+    val version: Property<String> = objectFactory.property()
 
     /**
      * Enable verbose mode.

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -37,7 +37,7 @@ open class KtlintExtension(
      * <p>
      * Example: `ignoreFailures = true`
      */
-    var ignoreFailures = false
+    val ignoreFailures: Property<Boolean> = objectFactory.property()
     /**
      * The ruleset(s) of ktlint to use.
      */
@@ -60,5 +60,6 @@ open class KtlintExtension(
         verbose.set(false)
         debug.set(false)
         outputToConsole.set(true)
+        ignoreFailures.set(false)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -1,15 +1,20 @@
 package org.jlleitschuh.gradle.ktlint
 
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 /**
  * Extension class for configuring the [KtlintPlugin].
  */
-open class KtlintExtension {
+open class KtlintExtension(
+    project: Project
+) {
     /**
      * The version of ktlint to use.
      */
-    var version = "0.27.0"
+    val version: Property<String> = project.objects.property()
+
     /**
      * Enable verbose mode.
      */
@@ -48,4 +53,8 @@ open class KtlintExtension {
      * Default is plain.
      */
     var reporters: Array<ReporterType> = arrayOf(ReporterType.PLAIN)
+
+    init {
+        version.set("0.27.0")
+    }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -22,7 +22,7 @@ open class KtlintExtension(
     /**
      * Enable debug mode.
      */
-    var debug = false
+    val debug: Property<Boolean> = objectFactory.property()
     /**
      * Enable android mode.
      */
@@ -58,5 +58,6 @@ open class KtlintExtension(
         version.set("0.27.0")
         android.set(false)
         verbose.set(false)
+        debug.set(false)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -2,6 +2,7 @@ package org.jlleitschuh.gradle.ktlint
 
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 /**
@@ -52,5 +53,7 @@ open class KtlintExtension(
      *
      * Default is plain.
      */
-    var reporters: Array<ReporterType> = arrayOf(ReporterType.PLAIN)
+    val reporters: SetProperty<ReporterType> = objectFactory.setProperty {
+        set(setOf(ReporterType.PLAIN))
+    }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -26,7 +26,7 @@ open class KtlintExtension(
     /**
      * Enable android mode.
      */
-    var android = false
+    val android: Property<Boolean> = objectFactory.property()
     /**
      * Enable console output mode.
      */
@@ -56,5 +56,6 @@ open class KtlintExtension(
 
     init {
         version.set("0.27.0")
+        android.set(false)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -1,6 +1,7 @@
 package org.jlleitschuh.gradle.ktlint
 
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
@@ -42,7 +43,7 @@ open class KtlintExtension(
     /**
      * The ruleset(s) of ktlint to use.
      */
-    var ruleSets: Array<String> = arrayOf()
+    val ruleSets: ListProperty<String> = objectFactory.listProperty { set(emptyList()) }
 
     /**
      * Report output formats.

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -30,7 +30,7 @@ open class KtlintExtension(
     /**
      * Enable console output mode.
      */
-    var outputToConsole = true
+    val outputToConsole: Property<Boolean> = objectFactory.property()
     /**
      * Whether or not to allow the build to continue if there are warnings;
      * defaults to {@code false}, as for any other static code analysis tool.
@@ -59,5 +59,6 @@ open class KtlintExtension(
         android.set(false)
         verbose.set(false)
         debug.set(false)
+        outputToConsole.set(true)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
@@ -1,0 +1,13 @@
+package org.jlleitschuh.gradle.ktlint
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.process.JavaExecSpec
+import javax.inject.Inject
+
+open class KtlintFormatTask @Inject constructor(
+    objectFactory: ObjectFactory
+) : KtlintCheckTask(objectFactory) {
+    override fun additionalConfig(): (JavaExecSpec) -> Unit = {
+        it.args("-F")
+    }
+}

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
@@ -20,7 +20,6 @@ open class KtlintIdeaPlugin : Plugin<Project> {
     }
 
     private fun addApplyToIdeaTasks(rootProject: Project, extension: KtlintExtension) {
-        rootProject.logger.warn("Creating idea helper tasks")
         val ktLintConfig = createConfiguration(rootProject, extension)
 
         if (extension.isApplyToIdeaPerProjectAvailable()) {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
@@ -23,7 +23,7 @@ open class KtlintIdeaPlugin : Plugin<Project> {
         val ktLintConfig = createConfiguration(rootProject, extension)
 
         if (extension.isApplyToIdeaPerProjectAvailable()) {
-            rootProject.maybeCreateTask<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
+            rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
                 group = HELP_GROUP
                 description = "Generates IDEA built-in formatter rules and apply them to the project." +
                     "It will overwrite existing ones."
@@ -33,7 +33,7 @@ open class KtlintIdeaPlugin : Plugin<Project> {
             }
         }
 
-        rootProject.maybeCreateTask<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_GLOBALLY_TASK_NAME) {
+        rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_GLOBALLY_TASK_NAME) {
             group = HELP_GROUP
             description = "Generates IDEA built-in formatter rules and apply them globally " +
                 "(in IDEA user settings folder). It will overwrite existing ones."

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
@@ -26,7 +26,7 @@ open class KtlintIdeaPlugin : Plugin<Project> {
             description = "Generates IDEA built-in formatter rules and apply them to the project." +
                 "It will overwrite existing ones."
             classpath.setFrom(ktLintConfig)
-            android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
+            android.set(extension.android)
             globally.set(rootProject.provider { false })
             ktlintVersion.set(extension.version)
         }
@@ -36,7 +36,7 @@ open class KtlintIdeaPlugin : Plugin<Project> {
             description = "Generates IDEA built-in formatter rules and apply them globally " +
                 "(in IDEA user settings folder). It will overwrite existing ones."
             classpath.setFrom(ktLintConfig)
-            android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
+            android.set(extension.android)
             globally.set(rootProject.provider { true })
             ktlintVersion.set(extension.version)
         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
@@ -20,30 +20,27 @@ open class KtlintIdeaPlugin : Plugin<Project> {
     }
 
     private fun addApplyToIdeaTasks(rootProject: Project, extension: KtlintExtension) {
-        rootProject.afterEvaluate {
-            if (rootProject.tasks.findByName(APPLY_TO_IDEA_TASK_NAME) == null) {
-                val ktLintConfig = createConfiguration(rootProject, extension)
+        rootProject.logger.warn("Creating idea helper tasks")
+        val ktLintConfig = createConfiguration(rootProject, extension)
 
-                if (extension.isApplyToIdeaPerProjectAvailable()) {
-                    rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
-                        group = HELP_GROUP
-                        description = "Generates IDEA built-in formatter rules and apply them to the project." +
-                            "It will overwrite existing ones."
-                        classpath.setFrom(ktLintConfig)
-                        android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
-                        globally.set(rootProject.provider { false })
-                    }
-                }
-
-                rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_GLOBALLY_TASK_NAME) {
-                    group = HELP_GROUP
-                    description = "Generates IDEA built-in formatter rules and apply them globally " +
-                        "(in IDEA user settings folder). It will overwrite existing ones."
-                    classpath.setFrom(ktLintConfig)
-                    android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
-                    globally.set(rootProject.provider { true })
-                }
+        if (extension.isApplyToIdeaPerProjectAvailable()) {
+            rootProject.maybeCreateTask<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
+                group = HELP_GROUP
+                description = "Generates IDEA built-in formatter rules and apply them to the project." +
+                    "It will overwrite existing ones."
+                classpath.setFrom(ktLintConfig)
+                android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
+                globally.set(rootProject.provider { false })
             }
+        }
+
+        rootProject.maybeCreateTask<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_GLOBALLY_TASK_NAME) {
+            group = HELP_GROUP
+            description = "Generates IDEA built-in formatter rules and apply them globally " +
+                "(in IDEA user settings folder). It will overwrite existing ones."
+            classpath.setFrom(ktLintConfig)
+            android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
+            globally.set(rootProject.provider { true })
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
@@ -1,6 +1,5 @@
 package org.jlleitschuh.gradle.ktlint
 
-import net.swiftzer.semver.SemVer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -22,15 +21,14 @@ open class KtlintIdeaPlugin : Plugin<Project> {
     private fun addApplyToIdeaTasks(rootProject: Project, extension: KtlintExtension) {
         val ktLintConfig = createConfiguration(rootProject, extension)
 
-        if (extension.isApplyToIdeaPerProjectAvailable()) {
-            rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
-                group = HELP_GROUP
-                description = "Generates IDEA built-in formatter rules and apply them to the project." +
-                    "It will overwrite existing ones."
-                classpath.setFrom(ktLintConfig)
-                android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
-                globally.set(rootProject.provider { false })
-            }
+        rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
+            group = HELP_GROUP
+            description = "Generates IDEA built-in formatter rules and apply them to the project." +
+                "It will overwrite existing ones."
+            classpath.setFrom(ktLintConfig)
+            android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
+            globally.set(rootProject.provider { false })
+            ktlintVersion.set(extension.version)
         }
 
         rootProject.taskHelper<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_GLOBALLY_TASK_NAME) {
@@ -40,14 +38,7 @@ open class KtlintIdeaPlugin : Plugin<Project> {
             classpath.setFrom(ktLintConfig)
             android.set(rootProject.provider { extension.isAndroidFlagEnabled() })
             globally.set(rootProject.provider { true })
+            ktlintVersion.set(extension.version)
         }
     }
-
-    /**
-     * Checks if apply code style to IDEA IDE per project is available.
-     *
-     * Available since KtLint version `0.22.0`.
-     */
-    private fun KtlintExtension.isApplyToIdeaPerProjectAvailable() =
-        SemVer.parse(version) >= SemVer(0, 22, 0)
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -273,7 +273,7 @@ open class KtlintPlugin : Plugin<Project> {
         verbose.set(extension.verbose)
         debug.set(extension.debug)
         android.set(extension.android)
-        ignoreFailures.set(target.provider { extension.ignoreFailures })
+        ignoreFailures.set(extension.ignoreFailures)
         outputToConsole.set(extension.outputToConsole)
         ruleSets.set(target.provider { extension.ruleSets.toList() })
         reports.forEach { _, report ->

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -5,6 +5,7 @@ import com.android.build.gradle.FeaturePlugin
 import com.android.build.gradle.InstantAppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.TestPlugin
+import com.android.build.gradle.internal.VariantManager
 import net.swiftzer.semver.SemVer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -13,11 +14,9 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.HasConvention
-import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.Convention
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.StopExecutionException
 import org.jetbrains.kotlin.gradle.plugin.KonanArtifactContainer
 import org.jetbrains.kotlin.gradle.plugin.KonanExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
@@ -41,12 +40,12 @@ open class KtlintPlugin : Plugin<Project> {
     }
 
     private fun addKtLintTasksToKotlinPlugin(target: Project, extension: KtlintExtension) {
-        target.pluginManager.withPlugin("kotlin", applyKtLint(target, extension))
-        target.pluginManager.withPlugin("kotlin2js", applyKtLint(target, extension))
-        target.pluginManager.withPlugin("kotlin-platform-common", applyKtLint(target, extension))
-        target.pluginManager.withPlugin("kotlin-android", applyKtLintToAndroid(target, extension))
-        target.pluginManager.withPlugin("konan", applyKtLintKonanNative(target, extension))
-        target.pluginManager.withPlugin(
+        target.plugins.withId("kotlin", applyKtLint(target, extension))
+        target.plugins.withId("kotlin2js", applyKtLint(target, extension))
+        target.plugins.withId("kotlin-platform-common", applyKtLint(target, extension))
+        target.plugins.withId("kotlin-android", applyKtLintToAndroid(target, extension))
+        target.plugins.withId("konan", applyKtLintKonanNative(target, extension))
+        target.plugins.withId(
             "org.jetbrains.kotlin.native",
             applyKtLintNative(target, extension)
         )
@@ -55,28 +54,40 @@ open class KtlintPlugin : Plugin<Project> {
     private fun applyKtLint(
         target: Project,
         extension: KtlintExtension
-    ): (AppliedPlugin) -> Unit {
-        return {
-            target.afterEvaluate {
-                val ktLintConfig = createConfiguration(target, extension)
+    ): (Plugin<in Any>) -> Unit {
+        return { _ ->
+            val ktLintConfig = createConfiguration(target, extension)
 
-                target.theHelper<JavaPluginConvention>().sourceSets.forEach {
-                    val kotlinSourceSet: SourceDirectorySet = (it as HasConvention)
-                            .convention
-                            .getPluginHelper<KotlinSourceSet>()
-                            .kotlin
-                    val checkTask = createCheckTask(target, extension, it.name, ktLintConfig, kotlinSourceSet.sourceDirectories)
-                    addKtlintCheckTaskToProjectMetaCheckTask(target, checkTask)
-                    setCheckTaskDependsOnKtlintCheckTask(target, checkTask)
+            target.theHelper<JavaPluginConvention>().sourceSets.forEach { sourceSet ->
+                val kotlinSourceSet: SourceDirectorySet = (sourceSet as HasConvention)
+                    .convention
+                    .getPluginHelper<KotlinSourceSet>()
+                    .kotlin
+                val checkTask = createCheckTask(
+                    target,
+                    extension,
+                    sourceSet.name,
+                    ktLintConfig,
+                    kotlinSourceSet.sourceDirectories
+                )
 
-                    val runArgs = kotlinSourceSet.sourceDirectories.files.flatMap { baseDir ->
-                        KOTLIN_EXTENSIONS.map { "${baseDir.path}/**/*.$it" }
-                    }.toMutableSet()
-                    addAdditionalRunArgs(extension, runArgs)
+                addKtlintCheckTaskToProjectMetaCheckTask(target, checkTask)
+                setCheckTaskDependsOnKtlintCheckTask(target, checkTask)
 
-                    val ktlintSourceSetFormatTask = createFormatTask(target, it.name, ktLintConfig, kotlinSourceSet, runArgs)
-                    addKtlintFormatTaskToProjectMetaFormatTask(target, ktlintSourceSetFormatTask)
-                }
+                val runArgs = kotlinSourceSet.sourceDirectories.files.flatMap { baseDir ->
+                    KOTLIN_EXTENSIONS.map { "${baseDir.path}/**/*.$it" }
+                }.toMutableSet()
+                addAdditionalRunArgs(extension, runArgs)
+
+                val ktlintSourceSetFormatTask = createFormatTask(
+                    target,
+                    sourceSet.name,
+                    ktLintConfig,
+                    kotlinSourceSet,
+                    runArgs
+                )
+
+                addKtlintFormatTaskToProjectMetaFormatTask(target, ktlintSourceSetFormatTask)
             }
         }
     }
@@ -84,38 +95,63 @@ open class KtlintPlugin : Plugin<Project> {
     private fun applyKtLintToAndroid(
         target: Project,
         extension: KtlintExtension
-    ): (AppliedPlugin) -> Unit {
-        return {
-            target.afterEvaluate {
-                val ktLintConfig = createConfiguration(target, extension)
+    ): (Plugin<in Any>) -> Unit {
+        return { _ ->
+            val ktLintConfig = createConfiguration(target, extension)
 
-                val variantManager = when {
-                    target.plugins.hasPlugin(AppPlugin::class.java) -> target.plugins.findPlugin(AppPlugin::class.java)?.variantManager
-                    target.plugins.hasPlugin(LibraryPlugin::class.java) -> target.plugins.findPlugin(LibraryPlugin::class.java)?.variantManager
-                    target.plugins.hasPlugin(InstantAppPlugin::class.java) -> target.plugins.findPlugin(InstantAppPlugin::class.java)?.variantManager
-                    target.plugins.hasPlugin(FeaturePlugin::class.java) -> target.plugins.findPlugin(FeaturePlugin::class.java)?.variantManager
-                    target.plugins.hasPlugin(TestPlugin::class.java) -> target.plugins.findPlugin(TestPlugin::class.java)?.variantManager
-                    else -> throw StopExecutionException("Must be applied with 'android' or 'android-library' plugin.")
-                }
+            val createTasks: (VariantManager) -> Unit = { variantManager ->
+                // If project has not been yet evaluated - variant data will be empty.
+                // Calling this will ensure that variant data is available.
+                variantManager.populateVariantDataList()
 
-                variantManager?.variantScopes?.forEach {
-                    val sourceDirs = it.variantData.javaSources
-                            .fold(mutableListOf<File>()) { acc, configurableFileTree ->
-                                acc.add(configurableFileTree.dir)
-                                acc
-                            }
+                variantManager.variantScopes.forEach { variantScope ->
+                    val sourceDirs = variantScope.variantData.javaSources
+                        .fold(mutableListOf<File>()) { acc, configurableFileTree ->
+                            acc.add(configurableFileTree.dir)
+                            acc
+                        }
                     // Don't use it.variantData.javaSources directly as it will trigger some android tasks execution
                     val kotlinSourceDir = target.files(*sourceDirs.toTypedArray())
-                    val runArgs = it.variantData.javaSources.map { "${it.dir.path}/**/*.kt" }.toMutableSet()
+                    val runArgs = variantScope.variantData.javaSources.map { "${it.dir.path}/**/*.kt" }.toMutableSet()
                     addAdditionalRunArgs(extension, runArgs)
 
-                    val checkTask = createCheckTask(target, extension, it.fullVariantName, ktLintConfig, sourceDirs)
+                    val checkTask = createCheckTask(
+                        target,
+                        extension,
+                        variantScope.fullVariantName,
+                        ktLintConfig,
+                        sourceDirs
+                    )
+
                     addKtlintCheckTaskToProjectMetaCheckTask(target, checkTask)
                     setCheckTaskDependsOnKtlintCheckTask(target, checkTask)
 
-                    val ktlintSourceSetFormatTask = createFormatTask(target, it.fullVariantName, ktLintConfig, kotlinSourceDir, runArgs)
+                    val ktlintSourceSetFormatTask = createFormatTask(
+                        target,
+                        variantScope.fullVariantName,
+                        ktLintConfig,
+                        kotlinSourceDir,
+                        runArgs
+                    )
+
                     addKtlintFormatTaskToProjectMetaFormatTask(target, ktlintSourceSetFormatTask)
                 }
+            }
+
+            target.plugins.withId("com.android.application") { plugin ->
+                (plugin as AppPlugin).variantManager.run(createTasks)
+            }
+            target.plugins.withId("com.android.library") { plugin ->
+                (plugin as LibraryPlugin).variantManager.run(createTasks)
+            }
+            target.plugins.withId("com.android.instantapp") { plugin ->
+                (plugin as InstantAppPlugin).variantManager.run(createTasks)
+            }
+            target.plugins.withId("com.android.feature") { plugin ->
+                (plugin as FeaturePlugin).variantManager.run(createTasks)
+            }
+            target.plugins.withId("com.android.test") { plugin ->
+                (plugin as TestPlugin).variantManager.run(createTasks)
             }
         }
     }
@@ -123,23 +159,20 @@ open class KtlintPlugin : Plugin<Project> {
     private fun applyKtLintKonanNative(
         project: Project,
         extension: KtlintExtension
-    ): (AppliedPlugin) -> Unit {
+    ): (Plugin<in Any>) -> Unit {
         return { _ ->
-            project.afterEvaluate { _ ->
-                val ktLintConfig = createConfiguration(project, extension)
+            val ktLintConfig = createConfiguration(project, extension)
 
-                val compileTargets = project.theHelper<KonanExtension>().targets
-
-                project.theHelper<KonanArtifactContainer>().forEach { konanBuildingConfig ->
-                    addTasksForNativePlugin(project, extension, konanBuildingConfig.name, ktLintConfig) {
-                        compileTargets.fold(initial = emptyList()) { acc, target ->
-                            val compileTask = konanBuildingConfig.findByTarget(target)
-                            if (compileTask != null) {
-                                val sourceFiles = (compileTask as KonanCompileTask).srcFiles
-                                acc + sourceFiles
-                            } else {
-                                acc
-                            }
+            val compileTargets = project.theHelper<KonanExtension>().targets
+            project.theHelper<KonanArtifactContainer>().whenObjectAdded { buildConfig ->
+                addTasksForNativePlugin(project, extension, buildConfig.name, ktLintConfig) {
+                    compileTargets.fold(initial = emptyList()) { acc, target ->
+                        val compileTask = buildConfig.findByTarget(target)
+                        if (compileTask != null) {
+                            val sourceFiles = (compileTask as KonanCompileTask).srcFiles
+                            acc + sourceFiles
+                        } else {
+                            acc
                         }
                     }
                 }
@@ -150,18 +183,16 @@ open class KtlintPlugin : Plugin<Project> {
     private fun applyKtLintNative(
         project: Project,
         extension: KtlintExtension
-    ): (AppliedPlugin) -> Unit {
+    ): (Plugin<in Any>) -> Unit {
         return { _ ->
-            project.afterEvaluate { _ ->
-                val ktLintConfig = createConfiguration(project, extension)
+            val ktLintConfig = createConfiguration(project, extension)
 
-                project.components.withType(KotlinNativeComponent::class.java) { component ->
-                    addTasksForNativePlugin(project, extension, component.name, ktLintConfig) {
-                        component.konanTargets.get()
-                            .fold(initial = emptyList()) { acc, konanTarget ->
-                                acc + listOf(component.sources.getAllSources(konanTarget))
-                            }
-                    }
+            project.components.withType(KotlinNativeComponent::class.java) { component ->
+                addTasksForNativePlugin(project, extension, component.name, ktLintConfig) {
+                    component.konanTargets.get()
+                        .fold(initial = emptyList()) { acc, nativeTarget ->
+                            acc + listOf(component.sources.getAllSources(nativeTarget))
+                        }
                 }
             }
         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -272,7 +272,7 @@ open class KtlintPlugin : Plugin<Project> {
         android.set(extension.android)
         ignoreFailures.set(extension.ignoreFailures)
         outputToConsole.set(extension.outputToConsole)
-        ruleSets.set(target.provider { extension.ruleSets.toList() })
+        ruleSets.set(extension.ruleSets)
         reporters.set(extension.reporters)
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -288,7 +288,7 @@ open class KtlintPlugin : Plugin<Project> {
         ktLintConfig: Configuration,
         kotlinSourceDirectories: Iterable<*>
     ): Task {
-        return target.taskHelper<KtlintCheck>("ktlint${sourceSetName.capitalize()}Check") {
+        return target.taskHelper<KtlintCheckTask>("ktlint${sourceSetName.capitalize()}Check") {
             group = VERIFICATION_GROUP
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
             classpath.setFrom(ktLintConfig)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -271,7 +271,7 @@ open class KtlintPlugin : Plugin<Project> {
         sourceDirectories.setFrom(kotlinSourceDirectories)
         ktlintVersion.set(extension.version)
         verbose.set(extension.verbose)
-        debug.set(target.provider { extension.debug })
+        debug.set(extension.debug)
         android.set(extension.android)
         ignoreFailures.set(target.provider { extension.ignoreFailures })
         outputToConsole.set(target.provider { extension.outputToConsole })

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -240,7 +240,7 @@ open class KtlintPlugin : Plugin<Project> {
         return target.taskHelper<KtlintFormatTask>("ktlint${sourceSetName.capitalize()}Format") {
             group = FORMATTING_GROUP
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
-            configurePluginTask(target, extension, ktLintConfig, kotlinSourceDirectories)
+            configurePluginTask(extension, ktLintConfig, kotlinSourceDirectories)
         }
     }
 
@@ -254,12 +254,11 @@ open class KtlintPlugin : Plugin<Project> {
         return target.taskHelper<KtlintCheckTask>("ktlint${sourceSetName.capitalize()}Check") {
             group = VERIFICATION_GROUP
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
-            configurePluginTask(target, extension, ktLintConfig, kotlinSourceDirectories)
+            configurePluginTask(extension, ktLintConfig, kotlinSourceDirectories)
         }
     }
 
     private fun KtlintCheckTask.configurePluginTask(
-        target: Project,
         extension: KtlintExtension,
         ktLintConfig: Configuration,
         kotlinSourceDirectories: Iterable<*>

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -270,7 +270,7 @@ open class KtlintPlugin : Plugin<Project> {
         classpath.setFrom(ktLintConfig)
         sourceDirectories.setFrom(kotlinSourceDirectories)
         ktlintVersion.set(extension.version)
-        verbose.set(target.provider { extension.verbose })
+        verbose.set(extension.verbose)
         debug.set(target.provider { extension.debug })
         android.set(extension.android)
         ignoreFailures.set(target.provider { extension.ignoreFailures })

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -237,7 +237,10 @@ open class KtlintPlugin : Plugin<Project> {
     private fun addAdditionalRunArgs(extension: KtlintExtension, runArgs: MutableSet<String>) {
         if (extension.verbose) runArgs.add("--verbose")
         if (extension.debug) runArgs.add("--debug")
-        if (extension.isAndroidFlagEnabled()) runArgs.add("--android")
+        if (extension.android.get() &&
+            extension.version.isAndroidFlagAvailable()) {
+            runArgs.add("--android")
+        }
         if (extension.ruleSets.isNotEmpty()) {
             extension.ruleSets.forEach { runArgs.add("--ruleset=$it") }
         }
@@ -290,9 +293,10 @@ open class KtlintPlugin : Plugin<Project> {
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
             classpath.setFrom(ktLintConfig)
             sourceDirectories.setFrom(kotlinSourceDirectories)
+            ktlintVersion.set(extension.version)
             verbose.set(target.provider { extension.verbose })
             debug.set(target.provider { extension.debug })
-            android.set(target.provider { extension.isAndroidFlagEnabled() })
+            android.set(extension.android)
             ignoreFailures.set(target.provider { extension.ignoreFailures })
             outputToConsole.set(target.provider { extension.outputToConsole })
             ruleSets.set(target.provider { extension.ruleSets.toList() })

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -299,7 +299,7 @@ open class KtlintPlugin : Plugin<Project> {
             reports.forEach { _, report ->
                 report.enabled.set(target.provider {
                     val reporterType = report.reporterType
-                    reporterAvailable(extension.version, reporterType) && extension.reporters.contains(reporterType)
+                    reporterAvailable(extension.version.get(), reporterType) && extension.reporters.contains(reporterType)
                 })
                 report.outputFile.set(target.layout.buildDirectory.file(target.provider {
                     "reports/ktlint/ktlint-$sourceSetName.${report.reporterType.fileExtension}"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -274,7 +274,7 @@ open class KtlintPlugin : Plugin<Project> {
         debug.set(extension.debug)
         android.set(extension.android)
         ignoreFailures.set(target.provider { extension.ignoreFailures })
-        outputToConsole.set(target.provider { extension.outputToConsole })
+        outputToConsole.set(extension.outputToConsole)
         ruleSets.set(target.provider { extension.ruleSets.toList() })
         reports.forEach { _, report ->
             report.enabled.set(target.provider {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -4,6 +4,7 @@ import net.swiftzer.semver.SemVer
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.HelpTasksPlugin
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.nio.file.Path
@@ -15,7 +16,7 @@ internal fun createConfiguration(target: Project, extension: KtlintExtension) =
             mapOf(
                 "group" to "com.github.shyiko",
                 "name" to "ktlint",
-                "version" to extension.version
+                "version" to extension.version.get()
             )
         )
     }
@@ -78,7 +79,7 @@ private fun Path.isRootEditorConfig(): Boolean {
  * Android option is available from ktlint 0.12.0.
  */
 internal fun KtlintExtension.isAndroidFlagEnabled() =
-    android && SemVer.parse(version) >= SemVer(0, 12, 0)
+    android && SemVer.parse(version.get()) >= SemVer(0, 12, 0)
 
 internal const val VERIFICATION_GROUP = LifecycleBasePlugin.VERIFICATION_GROUP
 internal const val FORMATTING_GROUP = "Formatting"
@@ -88,3 +89,5 @@ internal const val FORMAT_PARENT_TASK_NAME = "ktlintFormat"
 internal const val APPLY_TO_IDEA_TASK_NAME = "ktlintApplyToIdea"
 internal const val APPLY_TO_IDEA_GLOBALLY_TASK_NAME = "ktlintApplyToIdeaGlobally"
 internal val KOTLIN_EXTENSIONS = listOf("kt", "kts")
+
+internal inline fun <reified T> ObjectFactory.property() = property(T::class.java)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -91,4 +91,6 @@ internal const val APPLY_TO_IDEA_TASK_NAME = "ktlintApplyToIdea"
 internal const val APPLY_TO_IDEA_GLOBALLY_TASK_NAME = "ktlintApplyToIdeaGlobally"
 internal val KOTLIN_EXTENSIONS = listOf("kt", "kts")
 
-internal inline fun <reified T> ObjectFactory.property() = property(T::class.java)
+internal inline fun <reified T> ObjectFactory.property(
+    configuration: Property<T>.() -> Unit = {}
+) = property(T::class.java).apply(configuration)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.HelpTasksPlugin
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.language.base.plugins.LifecycleBasePlugin
@@ -99,3 +100,7 @@ internal inline fun <reified T> ObjectFactory.property(
 internal inline fun <reified T> ObjectFactory.setProperty(
     configuration: SetProperty<T>.() -> Unit = {}
 ) = setProperty(T::class.java).apply(configuration)
+
+internal inline fun <reified T> ObjectFactory.listProperty(
+    configuration: ListProperty<T>.() -> Unit = {}
+) = listProperty(T::class.java).apply(configuration)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.HelpTasksPlugin
+import org.gradle.api.provider.Property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.nio.file.Path
 
@@ -78,8 +79,8 @@ private fun Path.isRootEditorConfig(): Boolean {
 /**
  * Android option is available from ktlint 0.12.0.
  */
-internal fun KtlintExtension.isAndroidFlagEnabled() =
-    android && SemVer.parse(version.get()) >= SemVer(0, 12, 0)
+internal fun Property<String>.isAndroidFlagAvailable() =
+    SemVer.parse(get()) >= SemVer(0, 12, 0)
 
 internal const val VERIFICATION_GROUP = LifecycleBasePlugin.VERIFICATION_GROUP
 internal const val FORMATTING_GROUP = "Formatting"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -1,6 +1,5 @@
 package org.jlleitschuh.gradle.ktlint
 
-import groovy.lang.Closure
 import net.swiftzer.semver.SemVer
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -23,24 +22,6 @@ internal fun createConfiguration(target: Project, extension: KtlintExtension) =
 
 internal inline fun <reified T : Task> Project.taskHelper(name: String, noinline configuration: T.() -> Unit): T {
     return this.tasks.create(name, T::class.java, configuration)
-}
-
-internal inline fun <reified T : Task> Project.maybeCreateTask(
-    name: String,
-    noinline configuration: T.() -> Unit
-): T {
-    return tasks.maybeCreate(name, T::class.java).apply { configure(closureOf(configuration)) }
-}
-
-// Port from Kotlin DSL
-fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> = KotlinClosure1(action, this, this)
-class KotlinClosure1<in T : Any?, V : Any>(
-    val function: T.() -> V?,
-    owner: Any? = null,
-    thisObject: Any? = null
-) : Closure<V?>(owner, thisObject) {
-    @Suppress("unused") // to be called dynamically by Groovy
-    fun doCall(it: T): V? = it.function()
 }
 
 internal const val EDITOR_CONFIG_FILE_NAME = ".editorconfig"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -7,6 +7,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.HelpTasksPlugin
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.nio.file.Path
 
@@ -94,3 +95,7 @@ internal val KOTLIN_EXTENSIONS = listOf("kt", "kts")
 internal inline fun <reified T> ObjectFactory.property(
     configuration: Property<T>.() -> Unit = {}
 ) = property(T::class.java).apply(configuration)
+
+internal inline fun <reified T> ObjectFactory.setProperty(
+    configuration: SetProperty<T>.() -> Unit = {}
+) = setProperty(T::class.java).apply(configuration)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -1,5 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
+import groovy.lang.Closure
 import net.swiftzer.semver.SemVer
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -22,6 +23,24 @@ internal fun createConfiguration(target: Project, extension: KtlintExtension) =
 
 internal inline fun <reified T : Task> Project.taskHelper(name: String, noinline configuration: T.() -> Unit): T {
     return this.tasks.create(name, T::class.java, configuration)
+}
+
+internal inline fun <reified T : Task> Project.maybeCreateTask(
+    name: String,
+    noinline configuration: T.() -> Unit
+): T {
+    return tasks.maybeCreate(name, T::class.java).apply { configure(closureOf(configuration)) }
+}
+
+// Port from Kotlin DSL
+fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> = KotlinClosure1(action, this, this)
+class KotlinClosure1<in T : Any?, V : Any>(
+    val function: T.() -> V?,
+    owner: Any? = null,
+    thisObject: Any? = null
+) : Closure<V?>(owner, thisObject) {
+    @Suppress("unused") // to be called dynamically by Groovy
+    fun doCall(it: T): V? = it.function()
 }
 
 internal const val EDITOR_CONFIG_FILE_NAME = ".editorconfig"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/reporter/ReporterType.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/reporter/ReporterType.kt
@@ -2,7 +2,11 @@ package org.jlleitschuh.gradle.ktlint.reporter
 
 import net.swiftzer.semver.SemVer
 
-enum class ReporterType(val reporterName: String, val availableSinceVersion: SemVer, val fileExtension: String) {
+enum class ReporterType(
+    val reporterName: String,
+    val availableSinceVersion: SemVer,
+    val fileExtension: String
+) {
     PLAIN("plain", SemVer(0, 9, 0), "txt"),
     PLAIN_GROUP_BY_FILE("plain?group_by_file", SemVer(0, 9, 0), "txt"),
     CHECKSTYLE("checkstyle", SemVer(0, 9, 0), "xml"),

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -27,7 +27,9 @@ class KtlintPluginTest : AbstractPluginTest() {
                     gradlePluginPortal()
                 }
 
-                ktlint.reporters = ["PLAIN", "CHECKSTYLE"]
+                import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
+                ktlint.reporters = [ReporterType.CHECKSTYLE, ReporterType.PLAIN]
             """.trimIndent())
         }
     }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -68,7 +68,7 @@ class KtlintPluginTest : AbstractPluginTest() {
 
         projectRoot.buildFile().appendText("""
 
-            ktlint.reporters = ["PLAIN_GROUP_BY_FILE", "CHECKSTYLE", "JSON"]
+            ktlint.reporters = [ReporterType.PLAIN_GROUP_BY_FILE, ReporterType.CHECKSTYLE, ReporterType.JSON]
         """.trimIndent())
 
         buildAndFail("ktlintCheck").apply {
@@ -86,29 +86,39 @@ class KtlintPluginTest : AbstractPluginTest() {
 
         projectRoot.buildFile().appendText("""
 
-            ktlint.reporters = ["JSON", property("reportType")]
+            ktlint.reporters = [ReporterType.JSON, ReporterType.PLAIN]
         """.trimIndent())
 
-        build("ktlintCheck", "-PreportType=PLAIN").apply {
+        build("ktlintCheck").apply {
             assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
             assertReportCreated(ReporterType.PLAIN)
             assertReportCreated(ReporterType.JSON)
         }
 
-        build("ktlintCheck", "-PreportType=PLAIN").apply {
+        build("ktlintCheck").apply {
             assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
             assertReportCreated(ReporterType.PLAIN)
             assertReportCreated(ReporterType.JSON)
             assertReportNotCreated(ReporterType.CHECKSTYLE)
         }
 
-        build("ktlintCheck", "-PreportType=PLAIN_GROUP_BY_FILE").apply {
+        projectRoot.buildFile().appendText("""
+
+            ktlint.reporters = [ReporterType.JSON, ReporterType.PLAIN_GROUP_BY_FILE]
+        """.trimIndent())
+
+        build("ktlintCheck").apply {
             assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
             assertReportCreated(ReporterType.PLAIN_GROUP_BY_FILE)
             assertReportCreated(ReporterType.JSON)
         }
 
-        build("ktlintCheck", "-PreportType=CHECKSTYLE").apply {
+        projectRoot.buildFile().appendText("""
+
+            ktlint.reporters = [ReporterType.JSON, ReporterType.CHECKSTYLE]
+        """.trimIndent())
+
+        build("ktlintCheck").apply {
             assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
             assertReportCreated(ReporterType.JSON)
             assertReportCreated(ReporterType.CHECKSTYLE)
@@ -164,7 +174,9 @@ class KtlintPluginTest : AbstractPluginTest() {
                         gradlePluginPortal()
                     }
 
-                    ktlint.reporters = ["PLAIN", "CHECKSTYLE"]
+                    import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
+                    ktlint.reporters = [ReporterType.PLAIN, ReporterType.CHECKSTYLE]
                 """.trimIndent())
                 settingsFile().writeText("""
                     buildCache {
@@ -204,7 +216,7 @@ class KtlintPluginTest : AbstractPluginTest() {
     }
 
     private fun reportLocation(reportType: ReporterType) =
-            projectRoot.resolve("build/reports/ktlint/ktlint-main.${reportType.fileExtension}")
+            projectRoot.resolve("build/reports/ktlint/ktlintMainCheck.${reportType.fileExtension}")
 
     @Test
     fun `should succeed check on clean sources`() {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -44,7 +44,7 @@ class KtlintPluginTest : AbstractPluginTest() {
         projectRoot.withCleanSources()
 
         buildAndFail("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(task(":ktlintMainCheck")?.outcome, equalTo(TaskOutcome.FAILED))
             assertThat(output, containsString("Ktlint versions less than 0.10.0 are not supported. Detected Ktlint version: 0.9.0."))
         }
     }
@@ -240,16 +240,16 @@ class KtlintPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `should not add ktlintApplyToIdea if ktlint version less then 0_22_0`() {
+    fun `should fail ktlintApplyToIdea if ktlint version less then 0_22_0`() {
         projectRoot.withCleanSources()
         projectRoot.buildFile().appendText("""
 
             ktlint.version = "0.10.0"
         """.trimIndent())
 
-        build(":tasks").apply {
-            // With space to not interfere with ktlintApplyToIdeaGlobally tasks
-            assertThat(output.contains("ktlintApplyToIdea ", ignoreCase = true), equalTo(false))
+        buildAndFail(":ktlintApplyToIdea").apply {
+            assertThat(task(":ktlintApplyToIdea")?.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(output, containsString("Apply per project in only available from ktlint 0.22.0"))
         }
     }
 

--- a/samples/android-app/build.gradle.kts
+++ b/samples/android-app/build.gradle.kts
@@ -44,5 +44,5 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    android = true
+    android.set(true)
 }

--- a/samples/kotlin-gradle/build.gradle
+++ b/samples/kotlin-gradle/build.gradle
@@ -1,3 +1,5 @@
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 apply plugin: 'kotlin'
 apply plugin: 'application'
@@ -9,7 +11,7 @@ dependencies {
 }
 
 ktlint {
+    debug = true
     verbose = true
-    // For now have to be uppercase, see https://github.com/gradle/gradle/issues/4030
-    reporters = ["CHECKSTYLE", "PLAIN"]
+    reporters = [ReporterType.CHECKSTYLE, ReporterType.PLAIN]
 }

--- a/samples/kotlin-js/build.gradle.kts
+++ b/samples/kotlin-js/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
 }

--- a/samples/kotlin-js/build.gradle.kts
+++ b/samples/kotlin-js/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 configure<KtlintExtension> {
     verbose.set(true)
     outputToConsole.set(true)
-    reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
+    reporters.set(setOf(ReporterType.CHECKSTYLE, ReporterType.JSON))
 }

--- a/samples/kotlin-js/build.gradle.kts
+++ b/samples/kotlin-js/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
 }

--- a/samples/kotlin-ks/build.gradle.kts
+++ b/samples/kotlin-ks/build.gradle.kts
@@ -21,5 +21,5 @@ dependencies {
 configure<KtlintExtension> {
     verbose.set(true)
     outputToConsole.set(true)
-    reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
+    reporters.set(setOf(ReporterType.CHECKSTYLE, ReporterType.JSON))
 }

--- a/samples/kotlin-ks/build.gradle.kts
+++ b/samples/kotlin-ks/build.gradle.kts
@@ -20,6 +20,6 @@ dependencies {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
 }

--- a/samples/kotlin-ks/build.gradle.kts
+++ b/samples/kotlin-ks/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
 }

--- a/samples/kotlin-multiplatform-common/build.gradle.kts
+++ b/samples/kotlin-multiplatform-common/build.gradle.kts
@@ -11,5 +11,5 @@ dependencies {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
 }

--- a/samples/kotlin-multiplatform-common/build.gradle.kts
+++ b/samples/kotlin-multiplatform-common/build.gradle.kts
@@ -10,6 +10,6 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
 }

--- a/samples/kotlin-multiplatform-js/build.gradle.kts
+++ b/samples/kotlin-multiplatform-js/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
 }

--- a/samples/kotlin-multiplatform-js/build.gradle.kts
+++ b/samples/kotlin-multiplatform-js/build.gradle.kts
@@ -11,6 +11,6 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
 }

--- a/samples/kotlin-multiplatform-jvm/build.gradle.kts
+++ b/samples/kotlin-multiplatform-jvm/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
 }

--- a/samples/kotlin-multiplatform-jvm/build.gradle.kts
+++ b/samples/kotlin-multiplatform-jvm/build.gradle.kts
@@ -11,6 +11,6 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
 }

--- a/samples/kotlin-native-konan/build.gradle.kts
+++ b/samples/kotlin-native-konan/build.gradle.kts
@@ -13,6 +13,6 @@ configure<KonanArtifactContainer> {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
 }

--- a/samples/kotlin-native-konan/build.gradle.kts
+++ b/samples/kotlin-native-konan/build.gradle.kts
@@ -14,5 +14,5 @@ configure<KonanArtifactContainer> {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
 }

--- a/samples/kotlin-native/build.gradle.kts
+++ b/samples/kotlin-native/build.gradle.kts
@@ -18,6 +18,6 @@ kotlinNativeSourceSets["main"].component {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
 }

--- a/samples/kotlin-native/build.gradle.kts
+++ b/samples/kotlin-native/build.gradle.kts
@@ -19,5 +19,5 @@ kotlinNativeSourceSets["main"].component {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
 }

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
 configure<KtlintExtension> {
     verbose.set(true)
-    outputToConsole = true
+    outputToConsole.set(true)
     ruleSets = arrayOf("../kotlin-rulesets-creating/build/libs/kotlin-rulesets-creating.jar")
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
 }

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -25,7 +25,5 @@ configure<KtlintExtension> {
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
 }
 
-afterEvaluate {
-    tasks.findByName("ktlintMainCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
-    tasks.findByName("ktlintTestCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
-}
+tasks.findByName("ktlintMainCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
+tasks.findByName("ktlintTestCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 configure<KtlintExtension> {
     verbose.set(true)
     outputToConsole.set(true)
-    ruleSets = arrayOf("../kotlin-rulesets-creating/build/libs/kotlin-rulesets-creating.jar")
+    ruleSets.set(listOf("../kotlin-rulesets-creating/build/libs/kotlin-rulesets-creating.jar"))
     reporters.set(setOf(ReporterType.CHECKSTYLE, ReporterType.JSON))
 }
 

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -22,7 +22,7 @@ configure<KtlintExtension> {
     verbose.set(true)
     outputToConsole.set(true)
     ruleSets = arrayOf("../kotlin-rulesets-creating/build/libs/kotlin-rulesets-creating.jar")
-    reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)
+    reporters.set(setOf(ReporterType.CHECKSTYLE, ReporterType.JSON))
 }
 
 tasks.findByName("ktlintMainCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 }
 
 configure<KtlintExtension> {
-    verbose = true
+    verbose.set(true)
     outputToConsole = true
     ruleSets = arrayOf("../kotlin-rulesets-creating/build/libs/kotlin-rulesets-creating.jar")
     reporters = arrayOf(ReporterType.CHECKSTYLE, ReporterType.JSON)


### PR DESCRIPTION
This should improve plugin configuration performance and fix deprecation issue in Gradle `4.10`.

Closes #122 and #111 