### PR TITLE
Remove custom wrapper task.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ apply {
     plugin("org.jlleitschuh.gradle.ktlint")
 }
 
-task<Wrapper>("wrapper") {
+tasks.withType(Wrapper::class.java) {
     gradleVersion = SamplesVersions.gradleWrapper
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -118,7 +118,7 @@ pluginBundle {
     }
 }
 
-task<Wrapper>("wrapper") {
+tasks.withType(Wrapper::class.java) {
     gradleVersion = PluginVersions.gradleWrapper
 }
 


### PR DESCRIPTION
This approach is deprecated in Gradle.