### PR TITLE
Fix plugin fails to configure android projects with flavors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
   - ?
 ### Fixed
-  - ?
+  - Fixed plugin fails to configure android project with flavors (#131)
 
 ## [6.0.0] - 2018-9-20
 ### Added

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -111,9 +111,11 @@ open class KtlintPlugin : Plugin<Project> {
                 addKtlintFormatTaskToProjectMetaFormatTask(target, ktlintSourceSetFormatTask)
             }
 
-            // Variant manager returns all sources for variant,
-            // so most probably main source set maybe checked several times.
-            // This approach creates one check tasks per one source set.
+            /*
+            Variant manager returns all sources for variant,
+            so most probably main source set maybe checked several times.
+            This approach creates one check tasks per one source set.
+            */
             val pluginConfigure: (Plugin<Any>) -> Unit = { _ ->
                 target.extensions.configure(BaseExtension::class.java) { ext ->
                     ext.sourceSets { sourceSet ->

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -116,7 +116,7 @@ open class KtlintPlugin : Plugin<Project> {
             so most probably main source set maybe checked several times.
             This approach creates one check tasks per one source set.
             */
-            val pluginConfigure: (Plugin<Any>) -> Unit = { _ ->
+            fun getPluginConfigureAction(): (Plugin<Any>) -> Unit = { _ ->
                 target.extensions.configure(BaseExtension::class.java) { ext ->
                     ext.sourceSets { sourceSet ->
                         sourceSet.all {
@@ -126,11 +126,11 @@ open class KtlintPlugin : Plugin<Project> {
                 }
             }
 
-            target.plugins.withId("com.android.application", pluginConfigure)
-            target.plugins.withId("com.android.library", pluginConfigure)
-            target.plugins.withId("com.android.instantapp", pluginConfigure)
-            target.plugins.withId("com.android.feature", pluginConfigure)
-            target.plugins.withId("com.android.test", pluginConfigure)
+            target.plugins.withId("com.android.application", getPluginConfigureAction())
+            target.plugins.withId("com.android.library", getPluginConfigureAction())
+            target.plugins.withId("com.android.instantapp", getPluginConfigureAction())
+            target.plugins.withId("com.android.feature", getPluginConfigureAction())
+            target.plugins.withId("com.android.test", getPluginConfigureAction())
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -112,10 +112,10 @@ open class KtlintPlugin : Plugin<Project> {
             }
 
             /*
-            Variant manager returns all sources for variant,
-            so most probably main source set maybe checked several times.
-            This approach creates one check tasks per one source set.
-            */
+             * Variant manager returns all sources for variant,
+             * so most probably main source set maybe checked several times.
+             * This approach creates one check tasks per one source set.
+             */
             fun getPluginConfigureAction(): (Plugin<Any>) -> Unit = { _ ->
                 target.extensions.configure(BaseExtension::class.java) { ext ->
                     ext.sourceSets { sourceSet ->

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -1,11 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.FeaturePlugin
-import com.android.build.gradle.InstantAppPlugin
-import com.android.build.gradle.LibraryPlugin
-import com.android.build.gradle.TestPlugin
-import com.android.build.gradle.internal.VariantManager
+import com.android.build.gradle.BaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -20,7 +15,6 @@ import org.jetbrains.kotlin.gradle.plugin.KonanExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.experimental.KotlinNativeComponent
 import org.jetbrains.kotlin.gradle.plugin.tasks.KonanCompileTask
-import java.io.File
 import kotlin.reflect.KClass
 
 /**
@@ -91,56 +85,50 @@ open class KtlintPlugin : Plugin<Project> {
         return { _ ->
             val ktLintConfig = createConfiguration(target, extension)
 
-            val createTasks: (VariantManager) -> Unit = { variantManager ->
-                // If project has not been yet evaluated - variant data will be empty.
-                // Calling this will ensure that variant data is available.
-                variantManager.populateVariantDataList()
+            fun createTasks(
+                fullVariantName: String,
+                sources: FileCollection
+            ) {
+                val checkTask = createCheckTask(
+                    target,
+                    extension,
+                    fullVariantName,
+                    ktLintConfig,
+                    sources
+                )
 
-                variantManager.variantScopes.forEach { variantScope ->
-                    val sourceDirs = variantScope.variantData.javaSources
-                        .fold(mutableListOf<File>()) { acc, configurableFileTree ->
-                            acc.add(configurableFileTree.dir)
-                            acc
+                addKtlintCheckTaskToProjectMetaCheckTask(target, checkTask)
+                setCheckTaskDependsOnKtlintCheckTask(target, checkTask)
+
+                val ktlintSourceSetFormatTask = createFormatTask(
+                    target,
+                    extension,
+                    fullVariantName,
+                    ktLintConfig,
+                    sources
+                )
+
+                addKtlintFormatTaskToProjectMetaFormatTask(target, ktlintSourceSetFormatTask)
+            }
+
+            // Variant manager returns all sources for variant,
+            // so most probably main source set maybe checked several times.
+            // This approach creates one check tasks per one source set.
+            val pluginConfigure: (Plugin<Any>) -> Unit = { _ ->
+                target.extensions.configure(BaseExtension::class.java) { ext ->
+                    ext.sourceSets { sourceSet ->
+                        sourceSet.all {
+                            createTasks(it.name, target.files(it.java.srcDirs))
                         }
-
-                    val checkTask = createCheckTask(
-                        target,
-                        extension,
-                        variantScope.fullVariantName,
-                        ktLintConfig,
-                        sourceDirs
-                    )
-
-                    addKtlintCheckTaskToProjectMetaCheckTask(target, checkTask)
-                    setCheckTaskDependsOnKtlintCheckTask(target, checkTask)
-
-                    val ktlintSourceSetFormatTask = createFormatTask(
-                        target,
-                        extension,
-                        variantScope.fullVariantName,
-                        ktLintConfig,
-                        sourceDirs
-                    )
-
-                    addKtlintFormatTaskToProjectMetaFormatTask(target, ktlintSourceSetFormatTask)
+                    }
                 }
             }
 
-            target.plugins.withId("com.android.application") { plugin ->
-                (plugin as AppPlugin).variantManager.run(createTasks)
-            }
-            target.plugins.withId("com.android.library") { plugin ->
-                (plugin as LibraryPlugin).variantManager.run(createTasks)
-            }
-            target.plugins.withId("com.android.instantapp") { plugin ->
-                (plugin as InstantAppPlugin).variantManager.run(createTasks)
-            }
-            target.plugins.withId("com.android.feature") { plugin ->
-                (plugin as FeaturePlugin).variantManager.run(createTasks)
-            }
-            target.plugins.withId("com.android.test") { plugin ->
-                (plugin as TestPlugin).variantManager.run(createTasks)
-            }
+            target.plugins.withId("com.android.application", pluginConfigure)
+            target.plugins.withId("com.android.library", pluginConfigure)
+            target.plugins.withId("com.android.instantapp", pluginConfigure)
+            target.plugins.withId("com.android.feature", pluginConfigure)
+            target.plugins.withId("com.android.test", pluginConfigure)
         }
     }
 

--- a/samples/android-app/build.gradle.kts
+++ b/samples/android-app/build.gradle.kts
@@ -26,6 +26,12 @@ configure<AppExtension> {
         }
     }
 
+    flavorDimensions("beer")
+    productFlavors {
+        register("weissbier")
+        register("kellerbier")
+    }
+
     compileOptions {
         setSourceCompatibility(JavaVersion.VERSION_1_8)
         setTargetCompatibility(JavaVersion.VERSION_1_8)


### PR DESCRIPTION
Rethink approach how plugin gets android project sources and now it
uses android plugins base extension information, rather then VariantManager.

This also removes check of the same code more then once.

Closes #131 