### PR TITLE
Hide specific source sets tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Update Kotlin to `1.2.71` version
   - Update Gradle to `4.10.2` version
   - Update default KtLint version to `0.27.0`
+  - Hide specific source sets tasks
 ### Removed
   - ?
 ### Fixed

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -238,7 +238,6 @@ open class KtlintPlugin : Plugin<Project> {
         kotlinSourceDirectories: Iterable<*>
     ): Task {
         return target.taskHelper<KtlintFormatTask>("ktlint${sourceSetName.capitalize()}Format") {
-            group = FORMATTING_GROUP
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
             configurePluginTask(extension, ktLintConfig, kotlinSourceDirectories)
         }
@@ -252,7 +251,6 @@ open class KtlintPlugin : Plugin<Project> {
         kotlinSourceDirectories: Iterable<*>
     ): Task {
         return target.taskHelper<KtlintCheckTask>("ktlint${sourceSetName.capitalize()}Check") {
-            group = VERIFICATION_GROUP
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
             configurePluginTask(extension, ktLintConfig, kotlinSourceDirectories)
         }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -4,6 +4,8 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.hasItems
+import org.hamcrest.CoreMatchers.startsWith
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThat
@@ -260,6 +262,45 @@ class KtlintPluginTest : AbstractPluginTest() {
         build(":ktlintApplyToIdeaGlobally").apply {
             assertThat(task(":ktlintApplyToIdeaGlobally")?.outcome, equalTo(TaskOutcome.SUCCESS))
             assertThat(ideaRootDir.listFiles().isNotEmpty(), equalTo(true))
+        }
+    }
+
+    @Test
+    fun `should show only plugin meta tasks in task output`() {
+        projectRoot.withCleanSources()
+
+        build("tasks").apply {
+            val ktlintTasks = output
+                .lineSequence()
+                .filter { it.startsWith("ktlint") }
+                .toList()
+
+            assertThat(ktlintTasks.size, equalTo(4))
+            assertThat(ktlintTasks, hasItems(
+                startsWith(CHECK_PARENT_TASK_NAME),
+                startsWith(FORMAT_PARENT_TASK_NAME),
+                startsWith(APPLY_TO_IDEA_TASK_NAME),
+                startsWith(APPLY_TO_IDEA_GLOBALLY_TASK_NAME)
+            ))
+        }
+    }
+
+    @Test
+    fun `should show all ktlint tasks in task output`() {
+        build("tasks", "--all").apply {
+            val ktlintTasks = output
+                .lineSequence()
+                .filter { it.startsWith("ktlint") }
+                .toList()
+
+            // Plus for main and test sources format and check tasks
+            assertThat(ktlintTasks.size, equalTo(8))
+            assertThat(ktlintTasks, hasItems(
+                startsWith(CHECK_PARENT_TASK_NAME),
+                startsWith(FORMAT_PARENT_TASK_NAME),
+                startsWith(APPLY_TO_IDEA_TASK_NAME),
+                startsWith(APPLY_TO_IDEA_GLOBALLY_TASK_NAME)
+            ))
         }
     }
 }


### PR DESCRIPTION
Meta tasks (`ktlintCheck` and `ktlintFormat`) in the project are still visible.

My intention is to reduce unnessesary information, as usually ktlint used by running just `ktlintCheck` (or `ktlintFormat`) tasks.

This hidden tasks can still be visible by running `./gradlew tasks --all`.