### PR TITLE
Pass relative paths to source files in project to ktlint.

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.process.JavaExecSpec
 import org.jlleitschuh.gradle.ktlint.reporter.KtlintReport
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
@@ -96,7 +97,7 @@ open class KtlintCheckTask @Inject constructor(
     ): (JavaExecSpec) -> Unit = { javaExecSpec ->
         javaExecSpec.classpath = classpath
         javaExecSpec.main = "com.github.shyiko.ktlint.Main"
-        javaExecSpec.args(getSource())
+        javaExecSpec.args(getSource().toRelativeFilesList())
         if (verbose.get()) {
             javaExecSpec.args("--verbose")
         }
@@ -144,6 +145,11 @@ open class KtlintCheckTask @Inject constructor(
         project.layout.buildDirectory.file(project.provider {
             "reports/ktlint/${this@KtlintCheckTask.name}.$fileExtension"
         })
+
+    private fun FileTree.toRelativeFilesList(): List<File> {
+        val baseDir = project.projectDir
+        return files.map { it.relativeTo(baseDir) }
+    }
 
     @get:OutputFiles
     val reportOutputFiles: Map<ReporterType, RegularFileProperty>


### PR DESCRIPTION
To reduce command line length - pass relative to current project paths
to source files.

Before this change:
```
Command: /opt/oracle-jdk-bin-1.8.0.192/bin/java -Dfile.encoding=UTF-8 -Duser.country=DE -Duser.language=en -Duser.variant -cp <big_classpath> com.github.shyiko.ktlint.Main /home/user/data/work/ktlint-gradle/samples/kotlin-ks/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/main.kt --verbose --reporter=plain --color --reporter=checkstyle,output=/home/user/data/work/ktlint-gradle/samples/kotlin-ks/build/reports/ktlint/ktlintMainCheck.xml --reporter=json,output=/home/user/data/work/ktlint-gradle/samples/kotlin-ks/build/reports/ktlint/ktlintMainCheck.json
```

After this change:
```
Command: /opt/oracle-jdk-bin-1.8.0.192/bin/java -Dfile.encoding=UTF-8 -Duser.country=DE -Duser.language=en -Duser.variant -cp <big_classpath> com.github.shyiko.ktlint.Main src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/main.kt --verbose --reporter=plain --color --reporter=checkstyle,output=/home/user/data/work/ktlint-gradle/samples/kotlin-ks/build/reports/ktlint/ktlintMainCheck.xml --reporter=json,output=/home/user/data/work/ktlint-gradle/samples/kotlin-ks/build/reports/ktlint/ktlintMainCheck.json
```

Possibly fixes #156 