### PR TITLE
Use variants dynamically to put sourceSets

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -157,7 +157,7 @@ open class KtlintPlugin : Plugin<Project> {
                 target.extensions.configure(BaseExtension::class.java) { ext ->
                     ext.variants.all { variant ->
                         val filesCallable = Callable { variant.sourceSets.flatMap { sourceSet -> sourceSet.javaDirectories } }
-                        createTasks(variant.name, target.files(files))
+                        createTasks(variant.name, target.files(filesCallable))
                     }
                 }
             }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -156,7 +156,7 @@ open class KtlintPlugin : Plugin<Project> {
             fun getPluginConfigureAction(): (Plugin<Any>) -> Unit = {
                 target.extensions.configure(BaseExtension::class.java) { ext ->
                     ext.variants.all { variant ->
-                        val files = variant.sourceSets.flatMap { sourceSet -> sourceSet.javaDirectories }
+                        val filesCallable = Callable { variant.sourceSets.flatMap { sourceSet -> sourceSet.javaDirectories } }
                         createTasks(variant.name, target.files(files))
                     }
                 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.gradle.plugin.experimental.KotlinNativeComponent
 import org.jetbrains.kotlin.gradle.plugin.konan.KonanArtifactContainer
 import org.jetbrains.kotlin.gradle.plugin.konan.KonanExtension
 import shadow.org.jetbrains.kotlin.gradle.plugin.tasks.KonanCompileTask
+import java.util.concurrent.Callable
 import kotlin.reflect.KClass
 
 /**
@@ -156,7 +157,9 @@ open class KtlintPlugin : Plugin<Project> {
             fun getPluginConfigureAction(): (Plugin<Any>) -> Unit = {
                 target.extensions.configure(BaseExtension::class.java) { ext ->
                     ext.variants.all { variant ->
-                        val filesCallable = Callable { variant.sourceSets.flatMap { sourceSet -> sourceSet.javaDirectories } }
+                        val filesCallable = Callable {
+                            variant.sourceSets.flatMap { sourceSet -> sourceSet.javaDirectories }
+                        }
                         createTasks(variant.name, target.files(filesCallable))
                     }
                 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.gradle.plugin.experimental.KotlinNativeComponent
 import org.jetbrains.kotlin.gradle.plugin.konan.KonanArtifactContainer
 import org.jetbrains.kotlin.gradle.plugin.konan.KonanExtension
 import shadow.org.jetbrains.kotlin.gradle.plugin.tasks.KonanCompileTask
-import java.util.concurrent.Callable
 import kotlin.reflect.KClass
 
 /**
@@ -156,18 +155,9 @@ open class KtlintPlugin : Plugin<Project> {
              */
             fun getPluginConfigureAction(): (Plugin<Any>) -> Unit = {
                 target.extensions.configure(BaseExtension::class.java) { ext ->
-                    ext.sourceSets { sourceSet ->
-                        sourceSet.all { androidSourceSet ->
-                            // Passing Callable, so returned FileCollection, will lazy evaluate it
-                            // only when task will need it.
-                            // Solves the problem of having additional source dirs in
-                            // current AndroidSourceSet, that are not available on eager
-                            // evaluation.
-                            createTasks(
-                                androidSourceSet.name,
-                                target.files(Callable { androidSourceSet.java.srcDirs })
-                            )
-                        }
+                    ext.variants.all { variant ->
+                        val files = variant.sourceSets.flatMap { sourceSet -> sourceSet.javaDirectories }
+                        createTasks(variant.name, target.files(files))
                     }
                 }
             }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -1,6 +1,13 @@
 package org.jlleitschuh.gradle.ktlint
 
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.FeatureExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import com.android.build.gradle.api.BaseVariant
 import net.swiftzer.semver.SemVer
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
@@ -104,3 +111,12 @@ internal inline fun <reified T> ObjectFactory.setProperty(
 internal inline fun <reified T> ObjectFactory.listProperty(
     configuration: ListProperty<T>.() -> Unit = {}
 ) = listProperty(T::class.java).apply(configuration)
+
+internal val BaseExtension.variants
+    get(): DomainObjectSet<out BaseVariant> = when (this) {
+        is AppExtension -> applicationVariants
+        is LibraryExtension -> libraryVariants
+        is FeatureExtension -> featureVariants
+        is TestExtension -> applicationVariants
+        else -> throw IllegalStateException("Not supported Android extension: $this")
+    }


### PR DESCRIPTION
Instead of resolving sourceSets from extension, resolve variants and use the sources defined in there.

Fixes #153 