### PR TITLE
Update plugin id in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:<current_version>"
+    classpath "org.jlleitschuh.gradle:ktlint-gradle:<current_version>"
   }
 }
 


### PR DESCRIPTION
Due to the gradle plugin portal changes, plugin id doesn't now have "gradle.plugin" prefix.

Closes #169 