### PR TITLE
Update SemVer to 1.1.1 version.

### DIFF
--- a/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
+++ b/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
@@ -3,7 +3,7 @@ object PluginVersions {
     val ktlintPlugin = "6.3.0"
     val gradlePublishPlugin = "0.10.0"
     val androidPlugin = "3.2.0"
-    val semver = "1.1.0"
+    val semver = "1.1.1"
     val gradleWrapper = "4.10.2"
     val junit = "4.12"
 }


### PR DESCRIPTION
New release of SemVer has proper pom published on bintray.

Related to #162 