### PR TITLE
Use SourceSet in task names and reports files names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - ?
 ### Changed
   - Update Kotlin to `1.3.10` version
+  - Breaking: check/format tasks for specific source sets
+  and according reports outputs now include `SourceSet` in their name(#170)
 ### Deleted
   - ?
 ### Fixed

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -124,13 +124,13 @@ open class KtlintPlugin : Plugin<Project> {
             val ktLintConfig = createConfiguration(target, extension)
 
             fun createTasks(
-                fullVariantName: String,
+                sourceSetName: String,
                 sources: FileCollection
             ) {
                 val checkTask = createCheckTask(
                     target,
                     extension,
-                    fullVariantName,
+                    sourceSetName,
                     ktLintConfig,
                     sources
                 )
@@ -141,7 +141,7 @@ open class KtlintPlugin : Plugin<Project> {
                 val ktlintSourceSetFormatTask = createFormatTask(
                     target,
                     extension,
-                    fullVariantName,
+                    sourceSetName,
                     ktLintConfig,
                     sources
                 )
@@ -273,7 +273,7 @@ open class KtlintPlugin : Plugin<Project> {
         ktLintConfig: Configuration,
         kotlinSourceDirectories: Iterable<*>
     ): Task {
-        return target.taskHelper<KtlintFormatTask>("ktlint${sourceSetName.capitalize()}Format") {
+        return target.taskHelper<KtlintFormatTask>(sourceSetName.sourceSetFormatTaskName()) {
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
             configurePluginTask(target, extension, ktLintConfig, kotlinSourceDirectories)
         }
@@ -286,7 +286,7 @@ open class KtlintPlugin : Plugin<Project> {
         ktLintConfig: Configuration,
         kotlinSourceDirectories: Iterable<*>
     ): Task {
-        return target.taskHelper<KtlintCheckTask>("ktlint${sourceSetName.capitalize()}Check") {
+        return target.taskHelper<KtlintCheckTask>(sourceSetName.sourceSetCheckTaskName()) {
             description = "Runs a check against all .kt files to ensure that they are formatted according to ktlint."
             configurePluginTask(target, extension, ktLintConfig, kotlinSourceDirectories)
         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -104,3 +104,13 @@ internal inline fun <reified T> ObjectFactory.setProperty(
 internal inline fun <reified T> ObjectFactory.listProperty(
     configuration: ListProperty<T>.() -> Unit = {}
 ) = listProperty(T::class.java).apply(configuration)
+
+/**
+ * Create check task name from source set name.
+ */
+internal fun String.sourceSetCheckTaskName() = "ktlint${capitalize()}SourceSetCheck"
+
+/**
+ * Create format task name from source set name.
+ */
+internal fun String.sourceSetFormatTaskName() = "ktlint${capitalize()}SourceSetFormat"

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -58,7 +58,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         projectRoot.withCleanSources()
 
         buildAndFail("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")?.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(task(":ktlintMainSourceSetCheck")?.outcome, equalTo(TaskOutcome.FAILED))
             assertThat(output, containsString("Ktlint versions less than 0.10.0 are not supported. Detected Ktlint version: 0.9.0."))
         }
     }
@@ -68,7 +68,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         projectRoot.withFailingSources()
 
         buildAndFail("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
             assertThat(output, containsString("Unnecessary space(s)"))
             assertReportCreated(ReporterType.PLAIN)
             assertReportCreated(ReporterType.CHECKSTYLE)
@@ -86,7 +86,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         """.trimIndent())
 
         buildAndFail("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
             assertThat(output, containsString("Unnecessary space(s)"))
             assertReportCreated(ReporterType.PLAIN_GROUP_BY_FILE)
             assertReportCreated(ReporterType.CHECKSTYLE)
@@ -104,13 +104,13 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         """.trimIndent())
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
             assertReportCreated(ReporterType.PLAIN)
             assertReportCreated(ReporterType.JSON)
         }
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
             assertReportCreated(ReporterType.PLAIN)
             assertReportCreated(ReporterType.JSON)
             assertReportNotCreated(ReporterType.CHECKSTYLE)
@@ -122,7 +122,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         """.trimIndent())
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
             assertReportCreated(ReporterType.PLAIN_GROUP_BY_FILE)
             assertReportCreated(ReporterType.JSON)
         }
@@ -133,7 +133,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         """.trimIndent())
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
             assertReportCreated(ReporterType.JSON)
             assertReportCreated(ReporterType.CHECKSTYLE)
             // TODO: Stale reports are not cleaned up
@@ -147,10 +147,10 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         projectRoot.createEditorconfigFile()
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
         }
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
         }
     }
 
@@ -160,12 +160,12 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         projectRoot.createEditorconfigFile()
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
         }
 
         projectRoot.modifyEditorconfigFile(100)
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
         }
     }
 
@@ -207,7 +207,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
                 .withArguments("ktlintCheck", "--build-cache")
                 .forwardOutput()
                 .build().apply {
-                    assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+                    assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
                 }
 
         GradleRunner.create()
@@ -215,7 +215,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
                 .withArguments("ktlintCheck", "--build-cache")
                 .forwardOutput()
                 .build().apply {
-                    assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.FROM_CACHE))
+                    assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.FROM_CACHE))
                 }
     }
 
@@ -230,7 +230,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
     }
 
     private fun reportLocation(reportType: ReporterType) =
-            projectRoot.resolve("build/reports/ktlint/ktlintMainCheck.${reportType.fileExtension}")
+            projectRoot.resolve("build/reports/ktlint/ktlintMainSourceSetCheck.${reportType.fileExtension}")
 
     @Test
     fun `should succeed check on clean sources`() {
@@ -238,7 +238,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         projectRoot.withCleanSources()
 
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
         }
     }
 
@@ -327,7 +327,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         """.trimIndent())
 
         build(":ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
         }
     }
 
@@ -345,7 +345,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         """.trimIndent())
 
         buildAndFail(":ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
         }
     }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginVersionTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginVersionTest.kt
@@ -38,7 +38,7 @@ class KtlintPluginVersionTest : AbstractPluginTest() {
     fun `with ktlint version equal to 0_20`() {
         projectRoot.buildScriptUsingKtlintVersion("0.20.0")
         build("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.SUCCESS))
         }
     }
 
@@ -46,7 +46,7 @@ class KtlintPluginVersionTest : AbstractPluginTest() {
     fun `with ktlint version less than 0_20`() {
         projectRoot.buildScriptUsingKtlintVersion("0.19.0")
         buildAndFail("ktlintCheck").apply {
-            assertThat(task(":ktlintMainCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
+            assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
         }
     }
 }

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -25,5 +25,5 @@ configure<KtlintExtension> {
     reporters.set(setOf(ReporterType.CHECKSTYLE, ReporterType.JSON))
 }
 
-tasks.findByName("ktlintMainCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
-tasks.findByName("ktlintTestCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
+tasks.findByName("ktlintMainSourceSetCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
+tasks.findByName("ktlintTestSourceSetCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")


### PR DESCRIPTION
After reflecting on last discussion in #153, I think that it is better to rename check/format tasks, so they include `SourceSet` in their name (generated reports names are adjusted as well).

This better reflects on what exactly sources task are working.

Related to #170 