### PR TITLE
Add meta tasks for Android variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-  - ?
+  - Meta tasks to run check or format on all sources in android variant. (#170)
+  Example: In an Android project with `foo` flavor,
+  `ktlintFooDebugSourceSetCheck` task will check the `foo` sourceSet (not main).
+  `ktlintFooDebugCheck` meta task will check all the sourceSets for `fooDebug` build variant.
 ### Changed
   - Update Kotlin to `1.3.10` version
   - Breaking: check/format tasks for specific source sets

--- a/README.md
+++ b/README.md
@@ -202,12 +202,16 @@ This repository provides following examples how to setup this plugin:
 
 ### Main tasks
 
-This plugin adds two tasks to every source set: `ktlint[source set name]Check` and `ktlint[source set name]Format`.
+This plugin adds two tasks to every source set: `ktlint[source set name]SourceSetCheck` and `ktlint[source set name]SourceSetFormat`.
 Additionally, a simple `ktlintCheck` task has also been added that checks all of the source sets for that project.
 Similarly, a `ktlintFormat` task has been added that formats all of the source sets.
 
 If the project has subprojects then the plugin also adds two meta tasks `ktlintCheck` and `ktlintFormat` to the root project that
 triggers the related tasks in the subprojects.
+
+Android projects, additionally, will have meta tasks for Android variants, that will process all source sets in variant.
+For example, if app has `foo` flavor, following meta tasks will be added:
+`ktlintFooDebugCheck`, `ktlintFooReleaseCheck`, `ktlintFooDebugFormat`, `ktlintFooReleaseFormat`.
 
 ### Additional helper tasks
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -396,6 +396,7 @@ open class KtlintPlugin : Plugin<Project> {
     /*
      * Helper functions used until Gradle Script Kotlin solidifies it's plugin API.
      */
+
     private inline fun <reified T : Any> Project.theHelper() =
         theHelper(T::class)
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -365,7 +365,7 @@ open class KtlintPlugin : Plugin<Project> {
         multiplatformTargetName: String? = null
     ): Task {
         val taskName = "ktlint${variantName.capitalize()}${multiplatformTargetName?.capitalize() ?: ""}Check"
-        return tasks.findByName(taskName) ?: task(taskName).apply {
+        return tasks.maybeCreate(taskName).apply {
             group = VERIFICATION_GROUP
             description = "Runs ktlint on all kotlin sources for android $variantName variant in this project."
         }
@@ -382,7 +382,7 @@ open class KtlintPlugin : Plugin<Project> {
         multiplatformTargetName: String? = null
     ): Task {
         val taskName = "ktlint${variantName.capitalize()}${multiplatformTargetName?.capitalize() ?: ""}Format"
-        return tasks.findByName(taskName) ?: task(taskName).apply {
+        return tasks.maybeCreate(taskName).apply {
             group = FORMATTING_GROUP
             description = "Runs ktlint formatter on all kotlin sources for android $variantName" +
                 " variant in this project."

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -169,6 +169,15 @@ open class KtlintPlugin : Plugin<Project> {
                             )
                         }
                     }
+
+                    ext.variants?.all { variant ->
+                        val variantCheckTask = target.getAndroidVariantMetaKtlintCheckTask(variant.name)
+                        val variantFormatTask = target.getAndroidVariantMetaKtlintFormatTask(variant.name)
+                        variant.sourceSets.forEach { sourceSet ->
+                            variantCheckTask.dependsOn(sourceSet.name.sourceSetCheckTaskName())
+                            variantFormatTask.dependsOn(sourceSet.name.sourceSetFormatTaskName())
+                        }
+                    }
                 }
             }
 
@@ -324,10 +333,27 @@ open class KtlintPlugin : Plugin<Project> {
             description = "Runs ktlint on all kotlin sources in this project."
         }
 
+    private fun Project.getAndroidVariantMetaKtlintCheckTask(
+        variantName: String
+    ): Task = tasks.findByName("ktlint${variantName.capitalize()}Check")
+        ?: task("ktlint${variantName.capitalize()}Check").apply {
+            group = VERIFICATION_GROUP
+            description = "Runs ktlint on all kotlin sources for android $variantName variant in this project."
+        }
+
     private fun Project.getMetaKtlintFormatTask(): Task = this.tasks.findByName(FORMAT_PARENT_TASK_NAME)
         ?: this.task(FORMAT_PARENT_TASK_NAME).apply {
             group = FORMATTING_GROUP
             description = "Runs the ktlint formatter on all kotlin sources in this project."
+        }
+
+    private fun Project.getAndroidVariantMetaKtlintFormatTask(
+        variantName: String
+    ): Task = tasks.findByName("ktlint${variantName.capitalize()}Format")
+        ?: task("ktlint${variantName.capitalize()}Format").apply {
+            group = FORMATTING_GROUP
+            description = "Runs ktlint formatter on all kotlin sources for android $variantName" +
+                " variant in this project."
         }
 
     private fun setCheckTaskDependsOnKtlintCheckTask(project: Project, ktlintCheck: Task) {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -1,6 +1,13 @@
 package org.jlleitschuh.gradle.ktlint
 
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.FeatureExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import com.android.build.gradle.api.BaseVariant
 import net.swiftzer.semver.SemVer
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
@@ -114,3 +121,14 @@ internal fun String.sourceSetCheckTaskName() = "ktlint${capitalize()}SourceSetCh
  * Create format task name from source set name.
  */
 internal fun String.sourceSetFormatTaskName() = "ktlint${capitalize()}SourceSetFormat"
+
+/**
+ * Get specific android variants from [BaseExtension].
+ */
+internal val BaseExtension.variants: DomainObjectSet<out BaseVariant>? get() = when (this) {
+    is AppExtension -> applicationVariants
+    is LibraryExtension -> libraryVariants
+    is FeatureExtension -> featureVariants
+    is TestExtension -> applicationVariants
+    else -> null // Instant app extension doesn't provide variants access
+}


### PR DESCRIPTION
This PR adds android variants meta tasks, that trigger tasks for all source sets in given variant.

For example running `ktlintKellerbierDebugCheck` meta task triggers following tasks:
```bash
$ ./gradlew :samples:android-app:ktlintKellerbierDebugCheck -m

:samples:android-app:ktlintDebugSourceSetCheck SKIPPED
:samples:android-app:ktlintKellerbierDebugSourceSetCheck SKIPPED
:samples:android-app:ktlintKellerbierSourceSetCheck SKIPPED
:samples:android-app:ktlintMainSourceSetCheck SKIPPED
:samples:android-app:ktlintKellerbierDebugCheck SKIPPED
```

Also added limited support for android projects in new Kotlin multiplatform plugin:
```bash
$ ./gradlew -m :samples:kotlin-mpp-android:ktlintKellerbierDebugAndroidLibCheck

:samples:kotlin-mpp-android:ktlintAndroidLibDebugSourceSetCheck SKIPPED
:samples:kotlin-mpp-android:ktlintAndroidLibKellerbierDebugSourceSetCheck SKIPPED
:samples:kotlin-mpp-android:ktlintAndroidLibKellerbierSourceSetCheck SKIPPED
:samples:kotlin-mpp-android:ktlintAndroidLibMainSourceSetCheck SKIPPED
:samples:kotlin-mpp-android:ktlintKellerbierDebugAndroidLibCheck SKIPPED
```

Currently variant task name is inconsistent with source sets tasks names, but that will be addressed in #182 issue.

Closes #170.