### PR TITLE
Avoid error due to failing resolution of aapt2-proto

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,8 +13,8 @@ group = "org.jlleitschuh.gradle"
 version = "6.4.0-SNAPSHOT"
 
 repositories {
-    jcenter()
     google()
+    jcenter()
     maven("https://dl.bintray.com/jetbrains/kotlin-native-dependencies")
 }
 


### PR DESCRIPTION
When building the plugin I get an error due to a failed resolution of `aapt2-proto.jar`.

<img width="1030" alt="screenshot 2019-01-09 at 11 53 13" src="https://user-images.githubusercontent.com/1219911/50912690-0453d000-1433-11e9-8de6-4b4bb0c7ba88.png">

This is an known issue, see https://stackoverflow.com/questions/52944598/could-not-find-aapt2-proto-jar
