### PR TITLE
Fix wrong up-to-date state of format task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Deleted
   - ?
 ### Fixed
-  - ?
+  - Format task may produce up-to-date state if sources was restored to pre-format state (#194)
 
 ## [6.3.1] - 2018-11-27
 ### Fixed

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
@@ -1,13 +1,31 @@
 package org.jlleitschuh.gradle.ktlint
 
+import org.gradle.api.file.FileTree
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.process.JavaExecSpec
 import javax.inject.Inject
 
+@CacheableTask
 open class KtlintFormatTask @Inject constructor(
     objectFactory: ObjectFactory
 ) : KtlintCheckTask(objectFactory) {
     override fun additionalConfig(): (JavaExecSpec) -> Unit = {
         it.args("-F")
     }
+
+    /**
+     * Fixes the issue when input file is restored to pre-format state and running format task again fails
+     * with "up-to-date" task state.
+     *
+     * Note this approach sets task to "up-to-date" only on 3rd run when both input and output sources are the same.
+     */
+    @OutputFiles
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.RELATIVE)
+    fun getOutputSources(): FileTree { return getSource() }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -66,6 +66,12 @@ abstract class AbstractPluginTest {
     protected
     fun File.withFailingSources() = createSourceFile("src/main/kotlin/fail-source.kt", """val  foo    =     "bar"""")
 
+    protected fun File.restoreFailingSources() {
+        val sourceFile = resolve("src/main/kotlin/fail-source.kt")
+        sourceFile.delete()
+        withFailingSources()
+    }
+
     protected
     fun File.withAlternativeFailingSources(baseDir: String) =
         createSourceFile("$baseDir/fail-source.kt", """val  foo    =     "bar"""")

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -348,4 +348,33 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
             assertThat(task(":ktlintMainSourceSetCheck")!!.outcome, equalTo(TaskOutcome.FAILED))
         }
     }
+
+    @Test
+    fun `Should always format again restored to pre-format state sources`() {
+        projectRoot.withFailingSources()
+        build(":ktlintFormat").apply {
+            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+
+        projectRoot.restoreFailingSources()
+
+        build(":ktlintFormat").apply {
+            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+    }
+
+    @Test
+    fun `Format task should be up-to-date on 3rd run`() {
+        projectRoot.withFailingSources()
+
+        build(":ktlintFormat").apply {
+            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+        build(":ktlintFormat").apply {
+            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome, equalTo(TaskOutcome.SUCCESS))
+        }
+        build(":ktlintFormat").apply {
+            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome, equalTo(TaskOutcome.UP_TO_DATE))
+        }
+    }
 }


### PR DESCRIPTION
Fixes #194: Format task may produce up-to-date state, if sources was restored to pre-format state, so task input considered to be cached from success run.

Current solution is not perfect, but, currently, there are no better ways in Gradle:
- on first run format changes the sources and produce stable output content 
- on second run gradle produces stable input content with the same output
- on third run task is considered "UP-TO-DATE" and cached
