### PR TITLE
Simplify tests setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,17 @@ Building the plugin: `./plugin/gradlew build`
 
 On how to run the current plugin snapshot check on sample projects: `./gradlew ktlintCheck`
 
+### Running tests from [IDEA IDE](https://www.jetbrains.com/idea/)
+
+To run tests in [IDEA IDE](https://www.jetbrains.com/idea/), 
+firstly you need to run following gradle task (or after any dependency change):
+
+```bash
+$ ./plugin/gradlew pluginUnderTestMetadata
+```
+
+Optionally you can add this step test run configuration.
+
 ## Links
 
 [Ktlint Gradle Plugin on the Gradle Plugin Registry](https://plugins.gradle.org/plugin/org.jlleitschuh.gradle.ktlint)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -15,6 +15,10 @@ repositories {
     maven("https://dl.bintray.com/jetbrains/kotlin-native-dependencies")
 }
 
+tasks.withType<PluginUnderTestMetadata>().configureEach {
+    pluginClasspath.from(configurations.compileOnly)
+}
+
 dependencies {
     compileOnly(gradleApi())
     compileOnly(kotlin("gradle-plugin", PluginVersions.kotlin))
@@ -116,20 +120,4 @@ pluginBundle {
 
 tasks.withType(Wrapper::class.java).configureEach {
     gradleVersion = PluginVersions.gradleWrapper
-}
-
-tasks {
-    val publishPluginsToTestRepository by creating {
-        dependsOn("publishPluginMavenPublicationToTestRepository")
-    }
-    val processTestResources: ProcessResources by getting
-    val writeTestProperties by creating(WriteProperties::class) {
-        outputFile = processTestResources.destinationDir.resolve("test.properties")
-        property("version", version)
-        property("kotlinVersion", PluginVersions.kotlin)
-    }
-    processTestResources.dependsOn(writeTestProperties)
-    "test" {
-        dependsOn(publishPluginsToTestRepository)
-    }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -2,10 +2,8 @@ package org.jlleitschuh.gradle.ktlint
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.util.TextUtil.normaliseFileSeparators
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
-import java.util.Properties
 
 abstract class AbstractPluginTest {
 
@@ -15,22 +13,18 @@ abstract class AbstractPluginTest {
     val projectRoot: File
         get() = temporaryFolder.resolve("plugin-test").apply { mkdirs() }
 
-    protected
-    fun buildscriptBlockWithUnderTestPlugin() =
+    protected fun pluginsBlockWithIdeaPlugin() =
         """
-            buildscript {
-                repositories { maven { url = "$testRepositoryPath" } }
-                dependencies {
-                    classpath("org.jlleitschuh.gradle:ktlint-gradle:${testProperties["version"]}")
-                }
+            plugins {
+                id("org.jlleitschuh.gradle.ktlint-idea")
             }
         """.trimIndent()
 
-    protected
-    fun pluginsBlockWithKotlinJvmPlugin() =
+    protected fun pluginsBlockWithMainPluginAndKotlinJvm() =
         """
             plugins {
-                id("org.jetbrains.kotlin.jvm") version "${testProperties["kotlinVersion"]}"
+                id 'org.jetbrains.kotlin.jvm'
+                id 'org.jlleitschuh.gradle.ktlint'
             }
         """.trimIndent()
 
@@ -46,18 +40,8 @@ abstract class AbstractPluginTest {
     fun gradleRunnerFor(vararg arguments: String): GradleRunner =
         GradleRunner.create()
             .withProjectDir(projectRoot)
+            .withPluginClasspath()
             .withArguments(arguments.toList() + "--stacktrace")
-
-    private
-    val testRepositoryPath
-        get() = normaliseFileSeparators(File("build/plugin-test-repository").absolutePath)
-
-    protected
-    val testProperties: Properties by lazy {
-        javaClass.getResourceAsStream("/test.properties").use {
-            Properties().apply { load(it) }
-        }
-    }
 
     protected
     fun File.withCleanSources() = createSourceFile("src/main/kotlin/clean-source.kt", """val foo = "bar"""")

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPluginTest.kt
@@ -10,11 +10,7 @@ class KtlintIdeaPluginTest : AbstractPluginTest() {
         projectRoot.apply {
             buildFile().writeText(
                 """
-                ${buildscriptBlockWithUnderTestPlugin()}
-
-                ${pluginsBlockWithKotlinJvmPlugin()}
-
-                apply plugin: "org.jlleitschuh.gradle.ktlint-idea"
+                ${pluginsBlockWithIdeaPlugin()}
 
                 repositories {
                     gradlePluginPortal()

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -25,11 +25,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
     fun setupBuild() {
         projectRoot.apply {
             buildFile().writeText("""
-                ${buildscriptBlockWithUnderTestPlugin()}
-
-                ${pluginsBlockWithKotlinJvmPlugin()}
-
-                apply plugin: "org.jlleitschuh.gradle.ktlint"
+                ${pluginsBlockWithMainPluginAndKotlinJvm()}
 
                 repositories {
                     gradlePluginPortal()
@@ -173,11 +169,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
             it.apply {
                 withCleanSources()
                 buildFile().writeText("""
-                    ${buildscriptBlockWithUnderTestPlugin()}
-
-                    ${pluginsBlockWithKotlinJvmPlugin()}
-
-                    apply plugin: "org.jlleitschuh.gradle.ktlint"
+                    ${pluginsBlockWithMainPluginAndKotlinJvm()}
 
                     repositories {
                         gradlePluginPortal()
@@ -198,20 +190,22 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         }
 
         GradleRunner.create()
-                .withProjectDir(originalLocation)
-                .withArguments("ktlintCheck", "--build-cache")
-                .forwardOutput()
-                .build().apply {
-                    assertThat(task(":ktlintMainSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                }
+            .withProjectDir(originalLocation)
+            .withPluginClasspath()
+            .withArguments("ktlintCheck", "--build-cache")
+            .forwardOutput()
+            .build().apply {
+                assertThat(task(":ktlintMainSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            }
 
         GradleRunner.create()
-                .withProjectDir(relocatedLocation)
-                .withArguments("ktlintCheck", "--build-cache")
-                .forwardOutput()
-                .build().apply {
-                    assertThat(task(":ktlintMainSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
-                }
+            .withProjectDir(relocatedLocation)
+            .withPluginClasspath()
+            .withArguments("ktlintCheck", "--build-cache")
+            .forwardOutput()
+            .build().apply {
+                assertThat(task(":ktlintMainSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
+            }
     }
 
     private

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginVersionTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginVersionTest.kt
@@ -10,11 +10,7 @@ class KtlintPluginVersionTest : AbstractPluginTest() {
 
     private fun File.buildScriptUsingKtlintVersion(version: String) {
         buildFile().writeText("""
-                ${buildscriptBlockWithUnderTestPlugin()}
-
-                ${pluginsBlockWithKotlinJvmPlugin()}
-
-                apply plugin: "org.jlleitschuh.gradle.ktlint"
+                ${pluginsBlockWithMainPluginAndKotlinJvm()}
 
                 repositories {
                     gradlePluginPortal()


### PR DESCRIPTION
Now tests are using `GradleRunner.withPluginClasspath()` method to inject plugin under test.

Closes #150.