### PR TITLE
Fix .editorconfig in project root is not considered as tasks input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
   - ?
 ### Fixed
-  - ?
+  - `.editorconfig` file in project root dir is not considered as tasks input (#209)
 
 ## [7.1.0] - 2019-02-05
 ### Added

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -39,7 +39,10 @@ open class KtlintCheckTask @Inject constructor(
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
-    internal val editorConfigFiles: FileCollection = getEditorConfigFiles(project)
+    internal val editorConfigFiles: FileCollection by lazy(LazyThreadSafetyMode.NONE) {
+        // Gradle will lazy evaluate this task input only on task execution
+        getEditorConfigFiles(project)
+    }
 
     @get:Input
     internal val ktlintVersion: Property<String> = objectFactory.property()

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -57,7 +57,7 @@ private tailrec fun searchEditorConfigFiles(
     fileCollection: FileCollection
 ): FileCollection {
     val editorConfigFC = projectPath.resolve(EDITOR_CONFIG_FILE_NAME)
-    val outputCollection = if (editorConfigFC != null) {
+    val outputCollection = if (editorConfigFC.toFile().exists()) {
         fileCollection.plus(project.files(editorConfigFC))
     } else {
         fileCollection
@@ -65,7 +65,7 @@ private tailrec fun searchEditorConfigFiles(
 
     val parentDir = projectPath.parent
     return if (parentDir != null &&
-        parentDir != project.rootDir.toPath() &&
+        projectPath != project.rootDir.toPath() &&
         !editorConfigFC.isRootEditorConfig()) {
         searchEditorConfigFiles(project, parentDir, outputCollection)
     } else {


### PR DESCRIPTION
This prevents task to reset UP-TO-DATE state on any changes to this file.

Fixes #209 