### PR TITLE
Add pre commit Git hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-  - ?
+  - Git pre-commit hook (#101):
+
+    Current implementation does not support `buildSrc` or composite builds.
 ### Changed
   - ?
 ### Removed
@@ -32,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [7.1.0] - 2019-02-05
 ### Added
+
   - Warning about using vulnerable ktlint version
 ### Changed
   - Default ktlint version is set to `0.30.0`

--- a/README.md
+++ b/README.md
@@ -227,16 +227,18 @@ Additionally plugin adds two task for project kotlin script files: `ktlintKotlin
 
 ### Additional helper tasks
 
-Two another tasks are added:
+Following additional  tasks are added:
 - `ktlintApplyToIdea` - The task generates IntelliJ IDEA (or Android Studio) Kotlin
-                        style files in the project `.idea/` folder.
+                        style files in the project `.idea/` folder. **Note** that this tasks will overwrite the existing style file.
 - `ktlintApplyToIdeaGlobally` - The task generates IntelliJ IDEA (or Android Studio) Kotlin
                                 style files in the user home IDEA
-                                (or Android Studio) settings folder.
+                                (or Android Studio) settings folder. **Note** that this task will overwrite the existing style file.
+- `addKtlintCheckGitPreCommitHook` - adds [Git](https://www.git-scm.com/) `pre-commit` hook, 
+that runs ktlint check over staged files.
+- `addKtlintFormatGitPreCommitHook` - adds [Git](https://www.git-scm.com/) `pre-commit` hook, 
+that runs ktlint format over staged files and adds fixed files back to commit.
 
-They are always added **only** to the root project.
-
-**Note** that this tasks will overwrite the existing style file.
+All this additional tasks are always added **only** to the root project.
 
 ## FAQ
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -1,0 +1,155 @@
+package org.jlleitschuh.gradle.ktlint
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.intellij.lang.annotations.Language
+import java.io.File
+import javax.inject.Inject
+
+internal const val FILTER_INCLUDE_PROPERTY_NAME = "internalKtlintGitFilter"
+
+@Language("Bash")
+internal val shShebang = """
+#!/bin/sh
+set -e
+
+""".trimIndent()
+
+internal const val startHookSection = "######## KTLINT-GRADLE HOOK START ########\n"
+internal const val endHookSection = "######## KTLINT-GRADLE HOOK END ########\n"
+
+@Language("Bash")
+internal fun generateGitHook(taskName: String) = """
+
+CHANGED_FILES="${'$'}(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.kts|\.kt/ { print $2}')"
+
+if [[ -z "${'$'}CHANGED_FILES" ]]; then
+    echo "No Kotlin staged files."
+    exit 0
+fi;
+
+echo "Running ktlint over these files:"
+echo "${'$'}CHANGED_FILES"
+
+./gradlew --quiet $taskName -P$FILTER_INCLUDE_PROPERTY_NAME="${'$'}CHANGED_FILES"
+
+echo "Completed ktlint run."
+
+while read -r file; do
+    if [[ -f ${'$'}file ]]; then
+        git add ${'$'}file
+    fi
+done <<< "${'$'}CHANGED_FILES"
+
+echo "Completed ktlint hook."
+
+""".trimIndent()
+
+internal fun KtlintPlugin.PluginHolder.addGitHookTasks() {
+    if (target.rootProject == target &&
+        target.checkGitIsPresent()) {
+        addInstallGitHookFormatTask()
+        addInstallGitHookCheckTask()
+    }
+}
+
+private val Project.gitFolder: File get() = rootProject.file(".git")
+private fun Project.checkGitIsPresent(): Boolean = gitFolder.exists()
+
+private fun KtlintPlugin.PluginHolder.addInstallGitHookFormatTask() {
+    target.tasks.register(
+        INSTALL_GIT_HOOK_FORMAT_TASK,
+        KtlintInstallGitHookTask::class.java
+    ) {
+        it.description = "Adds git hook to run ktlintFormat on changed files"
+        it.group = HELP_GROUP
+        it.taskName.set(FORMAT_PARENT_TASK_NAME)
+        it.gitHook.set(target.file(".git/hooks/pre-commit"))
+    }
+}
+
+private fun KtlintPlugin.PluginHolder.addInstallGitHookCheckTask() {
+    target.tasks.register(
+        INSTALL_GIT_HOOK_CHECK_TASK,
+        KtlintInstallGitHookTask::class.java
+    ) {
+        it.description = "Adds git hook to run ktlintCheck on changed files"
+        it.group = HELP_GROUP
+        it.taskName.set(CHECK_PARENT_TASK_NAME)
+        it.gitHook.set(target.file(".git/hooks/pre-commit"))
+    }
+}
+
+open class KtlintInstallGitHookTask @Inject constructor(
+    objectFactory: ObjectFactory,
+    projectLayout: ProjectLayout
+) : DefaultTask() {
+    @get:Input
+    internal val taskName: Property<String> = objectFactory.property(String::class.java)
+
+    @get:OutputFile
+    internal val gitHook: RegularFileProperty = projectLayout.fileProperty()
+
+    @TaskAction
+    fun installHook() {
+        val gitHookFile = gitHook.get().asFile
+        logger.info("Hook file: $gitHookFile")
+        if (!gitHookFile.exists()) {
+            gitHookFile.createNewFile()
+            gitHookFile.setExecutable(true)
+        }
+
+        if (gitHookFile.length() == 0L) {
+            gitHookFile.writeText(
+                "$shShebang$startHookSection${generateGitHook(taskName.get())}$endHookSection"
+            )
+            return
+        }
+
+        var hookContent = gitHookFile.readText()
+        if (hookContent.contains(startHookSection)) {
+            val startTagIndex = hookContent.indexOf(startHookSection)
+            val endTagIndex = hookContent.indexOf(endHookSection)
+            hookContent = hookContent.replaceRange(
+                startTagIndex,
+                endTagIndex,
+                "$startHookSection${generateGitHook(taskName.get())}"
+            )
+            gitHookFile.writeText(hookContent)
+        } else {
+            gitHookFile.appendText(
+                "$startHookSection${generateGitHook(taskName.get())}$endHookSection"
+            )
+        }
+    }
+}
+
+internal fun KtlintCheckTask.applyGitFilter() {
+    val projectRelativePath = project.rootDir.toPath()
+        .relativize(project.projectDir.toPath())
+        .toString()
+    val filesToInclude = (project.property(FILTER_INCLUDE_PROPERTY_NAME) as String)
+        .split('\n')
+        .filter { it.startsWith(projectRelativePath) }
+
+    if (filesToInclude.isNotEmpty()) {
+        include { fileTreeElement ->
+            if (fileTreeElement.isDirectory) {
+                true
+            } else {
+                filesToInclude.any {
+                    fileTreeElement.file.absolutePath.endsWith(it)
+                }
+            }
+        }
+    } else {
+        exclude("*")
+    }
+}

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -76,8 +76,12 @@ open class KtlintCheckTask @Inject constructor(
             .filter { it.enabled.get() }
 
     init {
-        KOTLIN_EXTENSIONS.forEach {
-            include("**/*.$it")
+        if (project.hasProperty(FILTER_INCLUDE_PROPERTY_NAME)) {
+            applyGitFilter()
+        } else {
+            KOTLIN_EXTENSIONS.forEach {
+                include("**/*.$it")
+            }
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -37,6 +37,7 @@ open class KtlintPlugin : Plugin<Project> {
 
         holder.addKtLintTasksToKotlinPlugin()
         holder.addKotlinScriptTasks()
+        holder.addGitHookTasks()
     }
 
     private fun PluginHolder.addKtLintTasksToKotlinPlugin() {
@@ -400,7 +401,7 @@ open class KtlintPlugin : Plugin<Project> {
 
     private fun Project.isConsolePlain() = gradle.startParameter.consoleOutput == ConsoleOutput.Plain
 
-    private class PluginHolder(
+    internal class PluginHolder(
         val target: Project
     ) {
         val extension = target.plugins.apply(KtlintBasePlugin::class.java).extension

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -100,6 +100,8 @@ internal const val APPLY_TO_IDEA_TASK_NAME = "ktlintApplyToIdea"
 internal const val APPLY_TO_IDEA_GLOBALLY_TASK_NAME = "ktlintApplyToIdeaGlobally"
 internal const val KOTLIN_SCRIPT_CHECK_TASK = "ktlintKotlinScriptCheck"
 internal const val KOTLIN_SCRIPT_FORMAT_TASK = "ktlintKotlinScriptFormat"
+internal const val INSTALL_GIT_HOOK_CHECK_TASK = "addKtlintCheckGitPreCommitHook"
+internal const val INSTALL_GIT_HOOK_FORMAT_TASK = "addKtlintFormatGitPreCommitHook"
 internal val KOTLIN_EXTENSIONS = listOf("kt", "kts")
 
 internal inline fun <reified T> ObjectFactory.property(

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -1,0 +1,116 @@
+package org.jlleitschuh.gradle.ktlint
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class GitHookTasksTest : AbstractPluginTest() {
+    @BeforeEach
+    internal fun setUp() {
+        //language=Groovy
+        projectRoot.buildFile().writeText("""
+            ${pluginsBlockWithMainPluginAndKotlinJvm()}
+
+            repositories {
+                gradlePluginPortal()
+            }
+        """.trimIndent())
+    }
+
+    @Test
+    internal fun `Should not add install git hook tasks to submodule`() {
+        val submoduleDir = projectRoot.resolve("some-module").also { it.mkdir() }
+        projectRoot.createGitHookFolder()
+        projectRoot.settingsFile().writeText("""
+            include ":some-module"
+        """.trimIndent())
+        //language=Groovy
+        submoduleDir.buildFile().writeText("""
+            apply plugin: "kotlin"
+            apply plugin: "org.jlleitschuh.gradle.ktlint"
+        """.trimIndent())
+
+        buildAndFail(":some-module:$INSTALL_GIT_HOOK_CHECK_TASK").run {
+            assertThat(output).contains("Task '$INSTALL_GIT_HOOK_CHECK_TASK' not found in project")
+        }
+        buildAndFail(":some-module:$INSTALL_GIT_HOOK_FORMAT_TASK").run {
+            assertThat(output).contains("Task '$INSTALL_GIT_HOOK_FORMAT_TASK' not found in project")
+        }
+    }
+
+    @Test
+    internal fun `Should not add install git hook tasks to root project if git folder is not exist`() {
+        buildAndFail(":$INSTALL_GIT_HOOK_CHECK_TASK").run {
+            assertThat(output).contains("Task '$INSTALL_GIT_HOOK_CHECK_TASK' not found in root project")
+        }
+        buildAndFail(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
+            assertThat(output).contains("Task '$INSTALL_GIT_HOOK_FORMAT_TASK' not found in root project")
+        }
+    }
+
+    @Test
+    internal fun `Running install git hook check task should create pre-commit hook`() {
+        projectRoot.createGitHookFolder()
+
+        build(":$INSTALL_GIT_HOOK_CHECK_TASK").run {
+            assertThat(task(":$INSTALL_GIT_HOOK_CHECK_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(projectRoot.preCommitGitHook()).exists()
+            assertThat(projectRoot.preCommitGitHook().canExecute()).isTrue()
+            assertThat(projectRoot.preCommitGitHook().readText()).contains(CHECK_PARENT_TASK_NAME)
+        }
+    }
+
+    @Test
+    internal fun `Running install git hook format task should create pre-commit hook`() {
+        projectRoot.createGitHookFolder()
+
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
+            assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(projectRoot.preCommitGitHook()).exists()
+            assertThat(projectRoot.preCommitGitHook().canExecute()).isTrue()
+            assertThat(projectRoot.preCommitGitHook().readText()).contains(FORMAT_PARENT_TASK_NAME)
+        }
+    }
+
+    @Test
+    internal fun `Should produce same hook on second run`() {
+        projectRoot.createGitHookFolder()
+
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK")
+        val hookFileContent = projectRoot.preCommitGitHook().readText()
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK")
+        assertThat(projectRoot.preCommitGitHook().readText()).isEqualTo(hookFileContent)
+    }
+
+    @Test
+    internal fun `Should not touch already existing hooks`() {
+        projectRoot.createGitHookFolder()
+        projectRoot.preCommitGitHook().writeText("""
+            $shShebang
+
+            echo "test1"
+            $startHookSection
+
+
+            $endHookSection
+            echo "test2"
+        """.trimIndent())
+
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK")
+
+        val hookContent = projectRoot.preCommitGitHook().readText()
+
+        assertThat(hookContent).startsWith("""
+            $shShebang
+
+            echo "test1"
+        """.trimIndent())
+        assertThat(hookContent).endsWith("echo \"test2\"")
+    }
+
+    private fun File.preCommitGitHook(): File = gitHookFolder().resolve("pre-commit")
+    private fun File.gitHookFolder(): File = resolve(".git/hooks/")
+    private fun File.createGitHookFolder() = gitHookFolder().mkdirs()
+}


### PR DESCRIPTION
Add two tasks that install Git `pre-commit` hook:
- `addKtlintCheckGitPreCommitHook`
- `addKtlintFormatGitPreCommitHook`

Hook itself collects all staged (going to be commited) `*.kt` or `*.kts` files and run over this files either ktlint check or format tasks, passing list of files using `-PinternalKtlintGitFilter` property.

This PR partially addresses #101. Currently there are no support for composite builds and `buildSrc` sub-projects. This support should be added in followup PRs.