### PR TITLE
Add support for pinterest package and group changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+ - Support different ktlint group/package name after pinterest ownership of ktlint project (#228)
+### Changed
+ - Default ktlint version to `0.32.0`. 
+
 ## [7.3.0] - 2019-04-10
 ### Added
   - Git pre-commit hook (#101):

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ktlint Gradle
 
-**Provides a convenient wrapper plugin over the [ktlint](https://github.com/shyiko/ktlint) project.**
+**Provides a convenient wrapper plugin over the [ktlint](https://github.com/pinterest/ktlint) project.**
 
 Latest plugin version: [7.3.0](/CHANGELOG.md#730---2019-04-10)
 
@@ -10,7 +10,7 @@ Latest plugin version: [7.3.0](/CHANGELOG.md#730---2019-04-10)
 [![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/jlleitschuh/gradle/ktlint/org.jlleitschuh.gradle.ktlint.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=gradlePluginPortal)](https://plugins.gradle.org/plugin/org.jlleitschuh.gradle.ktlint)
 
 This plugin creates convenient tasks in your Gradle project
-that run [ktlint](https://github.com/shyiko/ktlint) checks or do code
+that run [ktlint](https://github.com/pinterest/ktlint) checks or do code
 auto format.
 
 Plugin can be applied to any project, but only activates if that project has the kotlin plugin applied.
@@ -64,7 +64,7 @@ This API is available in new versions of gradle.
 
 Minimal supported [Gradle](www.gradle.org) version: `4.10`
 
-Minimal supported [ktlint](https://github.com/shyiko/ktlint) version: `0.22.0`
+Minimal supported [ktlint](https://github.com/pinterest/ktlint) version: `0.22.0`
 
 ### Ktlint plugin
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
@@ -1,6 +1,5 @@
 package org.jlleitschuh.gradle.ktlint
 
-import net.swiftzer.semver.SemVer
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
@@ -31,7 +30,7 @@ open class KtlintApplyToIdeaTask @Inject constructor(
     fun generate() {
         project.javaexec {
             it.classpath = classpath
-            it.main = resolveMainClassName()
+            it.main = resolveMainClassName(ktlintVersion.get())
             if (globally.get()) {
                 it.args("--apply-to-idea")
             } else {
@@ -43,10 +42,5 @@ open class KtlintApplyToIdeaTask @Inject constructor(
                 it.args("--android")
             }
         }
-    }
-
-    private fun resolveMainClassName() = when {
-        SemVer.parse(ktlintVersion.get()) < SemVer(0, 32, 0) -> "com.github.shyiko.ktlint.Main"
-        else -> "com.pinterest.ktlint.Main"
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintApplyToIdeaTask.kt
@@ -1,5 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
+import net.swiftzer.semver.SemVer
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
@@ -30,7 +31,7 @@ open class KtlintApplyToIdeaTask @Inject constructor(
     fun generate() {
         project.javaexec {
             it.classpath = classpath
-            it.main = "com.github.shyiko.ktlint.Main"
+            it.main = resolveMainClassName()
             if (globally.get()) {
                 it.args("--apply-to-idea")
             } else {
@@ -42,5 +43,10 @@ open class KtlintApplyToIdeaTask @Inject constructor(
                 it.args("--android")
             }
         }
+    }
+
+    private fun resolveMainClassName() = when {
+        SemVer.parse(ktlintVersion.get()) < SemVer(0, 32, 0) -> "com.github.shyiko.ktlint.Main"
+        else -> "com.pinterest.ktlint.Main"
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -107,7 +107,7 @@ open class KtlintCheckTask @Inject constructor(
         additionalConfig: (JavaExecSpec) -> Unit
     ): (JavaExecSpec) -> Unit = { javaExecSpec ->
         javaExecSpec.classpath = classpath
-        javaExecSpec.main = resolveMainClassName()
+        javaExecSpec.main = resolveMainClassName(ktlintVersion.get())
         javaExecSpec.args(getSource().toRelativeFilesList())
         if (verbose.get()) {
             javaExecSpec.args("--verbose")
@@ -156,11 +156,6 @@ open class KtlintCheckTask @Inject constructor(
             SemVer.parse(ktlintVersion.get()) < SemVer(0, 31, 0)) {
             throw GradleException("Experimental rules are supported since 0.31.0 ktlint version.")
         }
-    }
-
-    private fun resolveMainClassName() = when {
-        SemVer.parse(ktlintVersion.get()) < SemVer(0, 32, 0) -> "com.github.shyiko.ktlint.Main"
-        else -> "com.pinterest.ktlint.Main"
     }
 
     private fun ReporterType.isAvailable() =

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -107,7 +107,7 @@ open class KtlintCheckTask @Inject constructor(
         additionalConfig: (JavaExecSpec) -> Unit
     ): (JavaExecSpec) -> Unit = { javaExecSpec ->
         javaExecSpec.classpath = classpath
-        javaExecSpec.main = "com.github.shyiko.ktlint.Main"
+        javaExecSpec.main = resolveMainClassName()
         javaExecSpec.args(getSource().toRelativeFilesList())
         if (verbose.get()) {
             javaExecSpec.args("--verbose")
@@ -156,6 +156,11 @@ open class KtlintCheckTask @Inject constructor(
             SemVer.parse(ktlintVersion.get()) < SemVer(0, 31, 0)) {
             throw GradleException("Experimental rules are supported since 0.31.0 ktlint version.")
         }
+    }
+
+    private fun resolveMainClassName() = when {
+        SemVer.parse(ktlintVersion.get()) < SemVer(0, 32, 0) -> "com.github.shyiko.ktlint.Main"
+        else -> "com.pinterest.ktlint.Main"
     }
 
     private fun ReporterType.isAvailable() =

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -22,7 +22,7 @@ internal constructor(
     /**
      * The version of ktlint to use.
      */
-    val version: Property<String> = objectFactory.property { set("0.31.0") }
+    val version: Property<String> = objectFactory.property { set("0.32.0") }
 
     /**
      * Enable verbose mode.
@@ -72,7 +72,7 @@ internal constructor(
     /**
      * Enable experimental ktlint rules.
      *
-     * You can find [here](https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-experimental/src/main/kotlin/com/github/shyiko/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt)
+     * You can find [here](https://github.com/pinterest/ktlint/blob/master/ktlint-ruleset-experimental/src/main/kotlin/com/pinterest/ktlint/ruleset/experimental/ExperimentalRuleSetProvider.kt)
      * list of experimental rules that will be enabled.
      *
      * @since ktlint `0.31.0`

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -6,6 +6,7 @@ import com.android.build.gradle.FeatureExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestExtension
 import com.android.build.gradle.api.BaseVariant
+import net.swiftzer.semver.SemVer
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -22,17 +23,23 @@ import java.nio.file.Path
 internal fun createConfiguration(target: Project, extension: KtlintExtension) =
     target.configurations.maybeCreate("ktlint").apply {
         this.incoming.beforeResolve {
-            target.logger.info("Add dependency: ktlint version ${extension.version.get()}")
+            val ktlintVersion = extension.version.get()
+            target.logger.info("Add dependency: ktlint version $ktlintVersion")
             target.dependencies.add(
                 this.name,
                 mapOf(
-                    "group" to "com.github.shyiko",
+                    "group" to resolveGroup(ktlintVersion),
                     "name" to "ktlint",
-                    "version" to extension.version.get()
+                    "version" to ktlintVersion
                 )
             )
         }
     }
+
+private fun resolveGroup(ktlintVersion: String) = when {
+    SemVer.parse(ktlintVersion) < SemVer(0, 32, 0) -> "com.github.shyiko"
+    else -> "com.pinterest"
+}
 
 internal inline fun <reified T : Task> Project.registerTask(
     name: String,
@@ -66,7 +73,8 @@ private tailrec fun searchEditorConfigFiles(
     val parentDir = projectPath.parent
     return if (parentDir != null &&
         projectPath != project.rootDir.toPath() &&
-        !editorConfigFC.isRootEditorConfig()) {
+        !editorConfigFC.isRootEditorConfig()
+    ) {
         searchEditorConfigFiles(project, parentDir, outputCollection)
     } else {
         outputCollection
@@ -143,10 +151,11 @@ internal fun String.androidVariantMetaFormatTaskName(
 /**
  * Get specific android variants from [BaseExtension].
  */
-internal val BaseExtension.variants: DomainObjectSet<out BaseVariant>? get() = when (this) {
-    is AppExtension -> applicationVariants
-    is LibraryExtension -> libraryVariants
-    is FeatureExtension -> featureVariants
-    is TestExtension -> applicationVariants
-    else -> null // Instant app extension doesn't provide variants access
-}
+internal val BaseExtension.variants: DomainObjectSet<out BaseVariant>?
+    get() = when (this) {
+        is AppExtension -> applicationVariants
+        is LibraryExtension -> libraryVariants
+        is FeatureExtension -> featureVariants
+        is TestExtension -> applicationVariants
+        else -> null // Instant app extension doesn't provide variants access
+    }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -41,6 +41,11 @@ private fun resolveGroup(ktlintVersion: String) = when {
     else -> "com.pinterest"
 }
 
+internal fun resolveMainClassName(ktlintVersion: String) = when {
+    SemVer.parse(ktlintVersion) < SemVer(0, 32, 0) -> "com.github.shyiko.ktlint.Main"
+    else -> "com.pinterest.ktlint.Main"
+}
+
 internal inline fun <reified T : Task> Project.registerTask(
     name: String,
     noinline configuration: T.() -> Unit

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -259,13 +259,11 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
             }
     }
 
-    private
-    fun assertReportCreated(reportType: ReporterType) {
+    private fun assertReportCreated(reportType: ReporterType) {
         assertThat(reportLocation(reportType).isFile).isTrue()
     }
 
-    private
-    fun assertReportNotCreated(reportType: ReporterType) {
+    private fun assertReportNotCreated(reportType: ReporterType) {
         assertThat(reportLocation(reportType).isFile).isFalse()
     }
 
@@ -415,6 +413,25 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
         build(":dependencies").apply {
             assertThat(output).contains("ktlint\n" +
                 "\\--- com.github.shyiko:ktlint:0.26.0\n")
+        }
+    }
+
+    @Test
+    fun `Should apply pinterest ktlint version from extension when the requested version is 0_32_0`() {
+        projectRoot.withCleanSources()
+
+        projectRoot.buildFile().appendText(
+            """
+
+            ktlint.version = "0.32.0"
+        """.trimIndent()
+        )
+
+        build(":dependencies").apply {
+            assertThat(output).contains(
+                "ktlint\n" +
+                        "\\--- com.pinterest:ktlint:0.32.0\n"
+            )
         }
     }
 


### PR DESCRIPTION
### Problem 

ktlint just released version 0.32.0 to fix a problem with Kotlin 1.3.30. But at the same time, they also changed the maven group id and package names. That is why just updating ktlint version to `0.32.0` breaks ktlint plugin.

### Solution

I've replaces groups and packages to support the new version. These changes here should be backward compatible.

### Considerations

Since this is only required when using version 0.32.0, I haven't changed the sample repo.
Added test that checks that the correct dependency is added.

Fixes #227 