### PR TITLE
3rd party ktlint rules configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-  - ?
+  - `ktlintRuleset` configuration to provide 3rd party ktlint rules (#71)
 ### Changed
   - Update Kotlin to `1.3.30` version
+  - Deprecated providing 3rd party ktlint rules via extension (#71)
 ### Fixed
   - Proper lazy adding ktlint dependency (#219)
 ### Removed

--- a/README.md
+++ b/README.md
@@ -159,10 +159,6 @@ ktlint {
     reporters = [ReporterType.PLAIN, ReporterType.CHECKSTYLE]
     ignoreFailures = true
     enableExperimentalRules = true
-    ruleSets = [
-        "/path/to/custom/rulseset.jar",
-        "com.github.username:rulseset:master-SNAPSHOT"
-    ]
     kotlinScriptAdditionalPaths {
         include fileTree("scripts/")
     }
@@ -170,6 +166,12 @@ ktlint {
         exclude("**/generated/**")
         include("**/kotlin/**")
     }
+}
+
+dependencies {
+    ktlintRuleset "com.github.username:rulseset:master-SNAPSHOT"
+    ktlintRuleset files("/path/to/custom/rulseset.jar")
+    ktlintRuleset project(":chore:project-ruleset") 
 }
 ```
 
@@ -186,10 +188,6 @@ ktlint {
     reporters.set(setOf(ReporterType.PLAIN, ReporterType.CHECKSTYLE))
     ignoreFailures.set(true)
     enableExperimentalRules.set(true)
-    ruleSets.set(listOf(
-        "/path/to/custom/rulseset.jar",
-        "com.github.username:rulseset:master-SNAPSHOT"
-    ))
     kotlinScriptAdditionalPaths {
         include(fileTree("scripts/"))
     }
@@ -197,6 +195,12 @@ ktlint {
         exclude("**/generated/**")
         include("**/kotlin/**")
     }
+}
+
+dependencies {
+    ktlintRuleset("com.github.username:rulseset:master-SNAPSHOT")
+    ktlintRuleset(files("/path/to/custom/rulseset.jar"))
+    ktlintRuleset(project(":chore:project-ruleset")) 
 }
 ```
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
@@ -6,6 +6,8 @@ import org.gradle.api.artifacts.Dependency
 
 internal const val KTLINT_CONFIGURATION_NAME = "ktlint"
 internal const val KTLINT_CONFIGURATION_DESCRIPTION = "Main ktlint-gradle configuration"
+internal const val KTLINT_RULESET_CONFIGURATION_NAME = "ktlintRuleset"
+internal const val KTLINT_RULESET_CONFIGURATION_DESCRIPTION = "All ktlint rulesets dependencies"
 
 internal fun createKtlintConfiguration(target: Project, extension: KtlintExtension) =
     target.configurations.maybeCreate(KTLINT_CONFIGURATION_NAME).apply {
@@ -28,3 +30,8 @@ private fun resolveGroup(ktlintVersion: String) = when {
     SemVer.parse(ktlintVersion) < SemVer(0, 32, 0) -> "com.github.shyiko"
     else -> "com.pinterest"
 }
+
+internal fun createKtlintRulesetConfiguration(target: Project) =
+    target.configurations.maybeCreate(KTLINT_RULESET_CONFIGURATION_NAME).apply {
+        description = KTLINT_RULESET_CONFIGURATION_DESCRIPTION
+    }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
@@ -1,0 +1,30 @@
+package org.jlleitschuh.gradle.ktlint
+
+import net.swiftzer.semver.SemVer
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+
+internal const val KTLINT_CONFIGURATION_NAME = "ktlint"
+internal const val KTLINT_CONFIGURATION_DESCRIPTION = "Main ktlint-gradle configuration"
+
+internal fun createKtlintConfiguration(target: Project, extension: KtlintExtension) =
+    target.configurations.maybeCreate(KTLINT_CONFIGURATION_NAME).apply {
+        description = KTLINT_CONFIGURATION_DESCRIPTION
+        val dependencyProvider = target.provider<Dependency> {
+            val ktlintVersion = extension.version.get()
+            target.logger.info("Add dependency: ktlint version $ktlintVersion")
+            target.dependencies.create(
+                mapOf(
+                    "group" to resolveGroup(ktlintVersion),
+                    "name" to "ktlint",
+                    "version" to ktlintVersion
+                )
+            )
+        }
+        dependencies.addLater(dependencyProvider)
+    }
+
+private fun resolveGroup(ktlintVersion: String) = when {
+    SemVer.parse(ktlintVersion) < SemVer(0, 32, 0) -> "com.github.shyiko"
+    else -> "com.pinterest"
+}

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -51,6 +51,8 @@ open class KtlintCheckTask @Inject constructor(
     internal val verbose: Property<Boolean> = objectFactory.property()
     @get:Input
     internal val ruleSets: ListProperty<String> = objectFactory.listProperty(String::class.java)
+    @get:Classpath
+    internal val ruleSetsClasspath: ConfigurableFileCollection = project.files()
     @get:Input
     internal val debug: Property<Boolean> = objectFactory.property()
     @get:Input
@@ -137,6 +139,7 @@ open class KtlintCheckTask @Inject constructor(
             javaExecSpec.args("--experimental")
         }
         javaExecSpec.args(ruleSets.get().map { "--ruleset=$it" })
+        javaExecSpec.args(ruleSetsClasspath.files.map { "--ruleset=${it.absolutePath}" })
         javaExecSpec.isIgnoreExitValue = ignoreFailures.get()
         javaExecSpec.args(enabledReports.map { it.asArgument() })
         additionalConfig(javaExecSpec)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -53,7 +53,15 @@ internal constructor(
     val ignoreFailures: Property<Boolean> = objectFactory.property { set(false) }
     /**
      * The ruleset(s) of ktlint to use.
+     *
+     * Deprecated - please, use instead ktlint ruleset configuration:
+     * ```kotlin
+     * dependencies {
+     *     ktlintRuleset("some:ktlint-rule:0.0.1")
+     * }
+     * ```
      */
+    @Deprecated("Please use $KTLINT_RULESET_CONFIGURATION_NAME configuration")
     val ruleSets: ListProperty<String> = objectFactory.listProperty { set(emptyList()) }
 
     /**

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintIdeaPlugin.kt
@@ -19,7 +19,7 @@ open class KtlintIdeaPlugin : Plugin<Project> {
     }
 
     private fun addApplyToIdeaTasks(rootProject: Project, extension: KtlintExtension) {
-        val ktLintConfig = createConfiguration(rootProject, extension)
+        val ktLintConfig = createKtlintConfiguration(rootProject, extension)
 
         rootProject.registerTask<KtlintApplyToIdeaTask>(APPLY_TO_IDEA_TASK_NAME) {
             group = HELP_GROUP

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -57,7 +57,7 @@ open class KtlintPlugin : Plugin<Project> {
     }
 
     private fun PluginHolder.applyKtlintMultiplatform(): (Plugin<in Any>) -> Unit = {
-        val ktLintConfig = createConfiguration(target, extension)
+        val ktLintConfig = createKtlintConfiguration(target, extension)
         val multiplatformExtension = target.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
         multiplatformExtension.sourceSets.all { sourceSet ->
@@ -104,7 +104,7 @@ open class KtlintPlugin : Plugin<Project> {
 
     private fun PluginHolder.applyKtLint(): (Plugin<in Any>) -> Unit {
         return {
-            val ktLintConfig = createConfiguration(target, extension)
+            val ktLintConfig = createKtlintConfiguration(target, extension)
 
             val sourceSets = target.theHelper<JavaPluginConvention>().sourceSets
 
@@ -139,7 +139,7 @@ open class KtlintPlugin : Plugin<Project> {
 
     private fun PluginHolder.applyKtLintToAndroid(): (Plugin<in Any>) -> Unit {
         return {
-            val ktLintConfig = createConfiguration(target, extension)
+            val ktLintConfig = createKtlintConfiguration(target, extension)
 
             fun createTasks(
                 sourceSetName: String,
@@ -202,7 +202,7 @@ open class KtlintPlugin : Plugin<Project> {
 
     private fun PluginHolder.applyKtLintKonanNative(): (Plugin<in Any>) -> Unit {
         return {
-            val ktLintConfig = createConfiguration(target, extension)
+            val ktLintConfig = createKtlintConfiguration(target, extension)
 
             val compileTargets = target.theHelper<KonanExtension>().targets
             target.theHelper<KonanArtifactContainer>().whenObjectAdded { buildConfig ->
@@ -223,7 +223,7 @@ open class KtlintPlugin : Plugin<Project> {
 
     private fun PluginHolder.applyKtLintNative(): (Plugin<in Any>) -> Unit {
         return {
-            val ktLintConfig = createConfiguration(target, extension)
+            val ktLintConfig = createKtlintConfiguration(target, extension)
             target.components.withType(KotlinNativeComponent::class.java) { component ->
                 addTasksForNativePlugin(component.name, ktLintConfig) {
                     component.konanTargets.get()
@@ -345,7 +345,7 @@ open class KtlintPlugin : Plugin<Project> {
     }
 
     private fun PluginHolder.addKotlinScriptTasks() {
-        val ktLintConfig = createConfiguration(target, extension)
+        val ktLintConfig = createKtlintConfiguration(target, extension)
 
         val projectDirectoryScriptFiles = target.fileTree(target.projectDir)
         projectDirectoryScriptFiles.include("*.kts")

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -294,6 +294,7 @@ open class KtlintPlugin : Plugin<Project> {
             }
         })
         ruleSets.set(pluginHolder.extension.ruleSets)
+        ruleSetsClasspath.setFrom(pluginHolder.ktlintRulesetConfiguration)
         reporters.set(pluginHolder.extension.reporters)
         android.set(pluginHolder.extension.android)
         enableExperimentalRules.set(pluginHolder.extension.enableExperimentalRules)
@@ -383,7 +384,8 @@ open class KtlintPlugin : Plugin<Project> {
             }
         }
 
-        val ktlintConfiguration by lazy { createKtlintConfiguration(target, extension) }
+        val ktlintConfiguration by lazy(LazyThreadSafetyMode.NONE) { createKtlintConfiguration(target, extension) }
+        val ktlintRulesetConfiguration = createKtlintRulesetConfiguration(target)
     }
 }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -10,7 +10,6 @@ import net.swiftzer.semver.SemVer
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.HelpTasksPlugin
@@ -20,30 +19,6 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import java.nio.file.Path
-
-internal const val KTLINT_CONFIGURATION_NAME = "ktlint"
-internal const val KTLINT_CONFIGURATION_DESCRIPTION = "Main ktlint-gradle configuration"
-internal fun createConfiguration(target: Project, extension: KtlintExtension) =
-    target.configurations.maybeCreate(KTLINT_CONFIGURATION_NAME).apply {
-        description = KTLINT_CONFIGURATION_DESCRIPTION
-        val dependencyProvider = target.provider<Dependency> {
-            val ktlintVersion = extension.version.get()
-            target.logger.info("Add dependency: ktlint version $ktlintVersion")
-            target.dependencies.create(
-                mapOf(
-                    "group" to resolveGroup(ktlintVersion),
-                    "name" to "ktlint",
-                    "version" to ktlintVersion
-                )
-            )
-        }
-        dependencies.addLater(dependencyProvider)
-    }
-
-private fun resolveGroup(ktlintVersion: String) = when {
-    SemVer.parse(ktlintVersion) < SemVer(0, 32, 0) -> "com.github.shyiko"
-    else -> "com.pinterest"
-}
 
 internal fun resolveMainClassName(ktlintVersion: String) = when {
     SemVer.parse(ktlintVersion) < SemVer(0, 32, 0) -> "com.github.shyiko.ktlint.Main"

--- a/samples/kotlin-rulesets-creating/build.gradle.kts
+++ b/samples/kotlin-rulesets-creating/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-    "compileOnly"(kotlin("stdlib"))
-    "compileOnly"(kotlin("reflect"))
-    "compileOnly"(kotlin("script-runtime"))
-    "compileOnly"("com.pinterest.ktlint:ktlint-core:${SamplesVersions.ktlintCore}")
+    compileOnly(kotlin("stdlib"))
+    compileOnly(kotlin("reflect"))
+    compileOnly(kotlin("script-runtime"))
+    compileOnly("com.pinterest.ktlint:ktlint-core:${SamplesVersions.ktlintCore}")
 }

--- a/samples/kotlin-rulesets-using/build.gradle.kts
+++ b/samples/kotlin-rulesets-using/build.gradle.kts
@@ -12,15 +12,11 @@ application {
 
 dependencies {
     compile(kotlin("stdlib"))
+    ktlintRuleset(project(":samples:kotlin-rulesets-creating"))
 }
 
 ktlint {
     verbose.set(true)
     outputToConsole.set(true)
-    ruleSets.set(listOf("../kotlin-rulesets-creating/build/libs/kotlin-rulesets-creating.jar"))
     reporters.set(setOf(ReporterType.CHECKSTYLE, ReporterType.JSON))
 }
-
-tasks.findByName("ktlintMainSourceSetCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
-tasks.findByName("ktlintTestSourceSetCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")
-tasks.findByName("ktlintKotlinScriptCheck")?.dependsOn(":samples:kotlin-rulesets-creating:build")


### PR DESCRIPTION
Added `ktlintRuleset` configuration that allows to provide 3rd party ktlint rules via `dependencies {}` block.

Deprecated related field in plugin extension. Should be removed on next major version change.

Closes #71 