### PR TITLE
Fix bashisms in git hook.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: android
 jdk:
   - oraclejdk8
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq devscripts
 install:
   - yes | sdkmanager --verbose "build-tools;26.0.2"
   - yes | sdkmanager --verbose "platform-tools"
@@ -12,6 +15,7 @@ script:
   - ./plugin/gradlew -p ./plugin build --no-daemon
   - ./plugin/gradlew -p ./plugin ktlintCheck --no-daemon
   - ./gradlew ktlintCheck --no-daemon
+  - ./gradlew addKtlintCheckGitPreCommitHook --no-daemon && checkbashisms .git/hooks/pre-commit
   - if [ -n "$TRAVIS_TAG" ]; then ./plugin/gradlew -p ./plugin publishPlugins --no-daemon; fi
 
 before_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
   - ?
 ### Fixed
-  - ?
+  - Usage of bashisms in git hook script (#251)
 
 ## [8.1.0] - 2019-06-16
 ### Added

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -25,12 +25,12 @@ set -e
 internal const val startHookSection = "######## KTLINT-GRADLE HOOK START ########\n"
 internal const val endHookSection = "######## KTLINT-GRADLE HOOK END ########\n"
 
-@Language("Bash")
+@Language("Sh")
 internal fun generateGitHook(taskName: String) = """
 
 CHANGED_FILES="${'$'}(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.kts|\.kt/ { print $2}')"
 
-if [[ -z "${'$'}CHANGED_FILES" ]]; then
+if [ -z "${'$'}CHANGED_FILES" ]; then
     echo "No Kotlin staged files."
     exit 0
 fi;
@@ -42,11 +42,11 @@ echo "${'$'}CHANGED_FILES"
 
 echo "Completed ktlint run."
 
-while read -r file; do
-    if [[ -f ${'$'}file ]]; then
+echo "${'$'}CHANGED_FILES" | while read -r file; do
+    if [ -f ${'$'}file ]; then
         git add ${'$'}file
     fi
-done <<< "${'$'}CHANGED_FILES"
+done
 
 echo "Completed ktlint hook."
 


### PR DESCRIPTION
This will allow to use in pure sh shells implementations.

Running `checkbashisms .git/hooks/pre-commit` produces no warnings.

Fixes #251 