### PR TITLE
Remove deprecated `ruleset` extension property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
   - Support for "konan" plugin
   - Support for "kotlin-native-gradle-plugin" plugin
+  - Deprecated `ruleset` extension property, please use `ruleset` configuration instead
 ### Fixed
   - ?
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -8,7 +8,6 @@ import org.gradle.api.file.FileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Classpath
@@ -50,8 +49,6 @@ abstract class BaseKtlintCheckTask(
     internal val ktlintVersion: Property<String> = objectFactory.property()
     @get:Input
     internal val verbose: Property<Boolean> = objectFactory.property()
-    @get:Input
-    internal val ruleSets: ListProperty<String> = objectFactory.listProperty(String::class.java)
     @get:Classpath
     internal val ruleSetsClasspath: ConfigurableFileCollection = project.files()
     @get:Input
@@ -136,7 +133,6 @@ abstract class BaseKtlintCheckTask(
         if (additionalEditorconfigFile.isPresent) {
             javaExecSpec.args("--editorconfig=${additionalEditorconfigFile.get().asFile.absolutePath}")
         }
-        javaExecSpec.args(ruleSets.get().map { "--ruleset=$it" })
         javaExecSpec.args(ruleSetsClasspath.files.map { "--ruleset=${it.absolutePath}" })
         javaExecSpec.isIgnoreExitValue = ignoreFailures.get()
         javaExecSpec.args(enabledReports.map { it.asArgument() })
@@ -151,7 +147,7 @@ abstract class BaseKtlintCheckTask(
     }
 
     private fun checkCWEKtlintVersion() {
-        if (!ruleSets.get().isNullOrEmpty() &&
+        if (!ruleSetsClasspath.isEmpty &&
             SemVer.parse(ktlintVersion.get()) < SemVer(0, 30, 0)) {
             logger.warn(
                 "You are using ktlint version ${ktlintVersion.get()} that has the security vulnerability " +

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -5,7 +5,6 @@ import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.util.PatternFilterable
@@ -54,18 +53,6 @@ internal constructor(
      * Example: `ignoreFailures = true`
      */
     val ignoreFailures: Property<Boolean> = objectFactory.property { set(false) }
-    /**
-     * The ruleset(s) of ktlint to use.
-     *
-     * Deprecated - please, use instead ktlint ruleset configuration:
-     * ```kotlin
-     * dependencies {
-     *     ktlintRuleset("some:ktlint-rule:0.0.1")
-     * }
-     * ```
-     */
-    @Deprecated("Please use $KTLINT_RULESET_CONFIGURATION_NAME configuration")
-    val ruleSets: ListProperty<String> = objectFactory.listProperty { set(emptyList()) }
 
     /**
      * Report output formats.

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -226,7 +226,6 @@ open class KtlintPlugin : Plugin<Project> {
                 it
             }
         })
-        ruleSets.set(pluginHolder.extension.ruleSets)
         ruleSetsClasspath.setFrom(pluginHolder.ktlintRulesetConfiguration)
         reporters.set(pluginHolder.extension.reporters)
         android.set(pluginHolder.extension.android)


### PR DESCRIPTION
Next release would have breaking changes, so it is good time remove deprecated properties.