### PR TITLE
Pass arguments to ktlint as file input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Support for "kotlin-native-gradle-plugin" plugin
   - Deprecated `ruleset` extension property, please use `ruleset` configuration instead
 ### Fixed
-  - Task may fail on command line arguments limit (#233)
+  - Task failing when command line arguments limit was reached (#233)
 
 ## [8.2.0] - 2019-07-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Support for "kotlin-native-gradle-plugin" plugin
   - Deprecated `ruleset` extension property, please use `ruleset` configuration instead
 ### Fixed
-  - ?
+  - Task may fail on command line arguments limit (#233)
 
 ## [8.2.0] - 2019-07-18
 ### Added

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -3,7 +3,7 @@ package org.jlleitschuh.gradle.ktlint
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.process.JavaExecSpec
+import java.io.PrintWriter
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
@@ -12,5 +12,5 @@ open class KtlintCheckTask @Inject constructor(
     objectFactory: ObjectFactory,
     projectLayout: ProjectLayout
 ) : BaseKtlintCheckTask(objectFactory, projectLayout) {
-    override fun additionalConfig(): (JavaExecSpec) -> Unit = {}
+    override fun additionalConfig(): (PrintWriter) -> Unit = {}
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.process.JavaExecSpec
+import java.io.PrintWriter
 import javax.inject.Inject
 
 @CacheableTask
@@ -16,8 +16,8 @@ open class KtlintFormatTask @Inject constructor(
     objectFactory: ObjectFactory,
     projectLayout: ProjectLayout
 ) : BaseKtlintCheckTask(objectFactory, projectLayout) {
-    override fun additionalConfig(): (JavaExecSpec) -> Unit = {
-        it.args("-F")
+    override fun additionalConfig(): (PrintWriter) -> Unit = {
+        it.println("-F")
     }
 
     /**


### PR DESCRIPTION
Ktlint starts using https://picocli.info/#AtFiles command line option, that
allows to pass arguments to command line invocation from file.
Such approach should solve maximum command line arguments limitation.

Don't need to bump minimum support ktlint version here as picoli dependency on ktlint project was introduced more then 2 years ago, before minimum supported version was released.

Sample of such "args" file for `:samples:kotlin-ks` project:
```
       │ File: samples/kotlin-ks/build/ktlint/ktlintMainSourceSetCheck.args
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ --verbose
   2   │ --reporter=plain
   3   │ --color
   4   │ --reporter=checkstyle,output=/home/egorr/data/work/ktlint-gradle/samples/kotlin-ks/build/reports/ktlint/ktlintMainSourceSetCheck.xml
   5   │ --reporter=json,output=/home/egorr/data/work/ktlint-gradle/samples/kotlin-ks/build/reports/ktlint/ktlintMainSourceSetCheck.json
   6   │ src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/main.kt
``` 

Closes #233 