### PR TITLE
Added output color name property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
-  - ?
+  - Support for outputColorName property (#297)
 ### Changed
   - Set default ktlint version to `0.35.0`
 ### Removed

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ ktlint {
     verbose = true
     android = false
     outputToConsole = true
+    outputColorName = "RED"
     ignoreFailures = true
     enableExperimentalRules = true
     additionalEditorconfigFile = file("/some/additional/.editorconfig")
@@ -201,6 +202,7 @@ ktlint {
     verbose.set(true)
     android.set(false)
     outputToConsole.set(true)
+    outputColorName.set("RED")
     ignoreFailures.set(true)
     enableExperimentalRules.set(true)
     additionalEditorconfigFile.set(file("/some/additional/.editorconfig"))

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -68,6 +68,8 @@ abstract class BaseKtlintCheckTask(
     @get:Console
     internal val coloredOutput: Property<Boolean> = objectFactory.property()
     @get:Input
+    internal val outputColorName: Property<String> = objectFactory.property()
+    @get:Input
     internal val enableExperimentalRules: Property<Boolean> = objectFactory.property()
     @get:Input
     internal val disabledRules: SetProperty<String> = objectFactory.setProperty()
@@ -188,6 +190,11 @@ abstract class BaseKtlintCheckTask(
                 .run {
                     if (isNotEmpty()) argsWriter.println("--disabled_rules=$this")
                 }
+            outputColorName
+                .get()
+                .run {
+                    if (isNotEmpty()) argsWriter.println("--color-name=$this")
+                } 
             getSource()
                 .toRelativeFilesList()
                 .forEach { argsWriter.println(it) }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -194,7 +194,7 @@ abstract class BaseKtlintCheckTask(
                 .get()
                 .run {
                     if (isNotEmpty()) argsWriter.println("--color-name=$this")
-                } 
+                }
             getSource()
                 .toRelativeFilesList()
                 .forEach { argsWriter.println(it) }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -56,6 +56,10 @@ internal constructor(
      */
     val coloredOutput: Property<Boolean> = objectFactory.property { set(true) }
     /**
+     * Specify the color of the terminal output.
+     */
+    val outputColorName: Property<String> = objectFactory.property { set("") }
+    /**
      * Whether or not to allow the build to continue if there are warnings;
      * defaults to {@code false}, as for any other static code analysis tool.
      * <p>

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -226,6 +226,7 @@ open class KtlintPlugin : Plugin<Project> {
                 it
             }
         })
+        outputColorName.set(pluginHolder.extension.outputColorName)
         ruleSetsClasspath.setFrom(pluginHolder.ktlintRulesetConfiguration)
         reporters.set(pluginHolder.extension.reporterExtension.reporters)
         customReportersClasspath.setFrom(pluginHolder.ktlintReporterConfiguration)

--- a/samples/android-app/build.gradle.kts
+++ b/samples/android-app/build.gradle.kts
@@ -55,4 +55,5 @@ dependencies {
 
 ktlint {
     android.set(true)
+    outputColorName.set("RED")
 }


### PR DESCRIPTION
This has support for the `--color-name` argument added in KtLint 0.35.0: https://github.com/pinterest/ktlint/pull/585

Tested by adding the property to the android-app sample, and forcing a failure.

Before:

<img width="1288" alt="Screen Shot 2019-10-20 at 6 48 40 PM" src="https://user-images.githubusercontent.com/9515997/67167689-ebd1f800-f36a-11e9-8bc4-42857a2bb53f.png">

After:

<img width="1291" alt="Screen Shot 2019-10-20 at 6 49 16 PM" src="https://user-images.githubusercontent.com/9515997/67167692-effe1580-f36a-11e9-86b2-f35c4008e17f.png">
