### PR TITLE
Add support for incremental task api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
   - Support for outputColorName property (#297)
+  - Support for incremental checks (#231)
 ### Changed
   - Set default ktlint version to `0.35.0`
 ### Removed

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ No. This approaches are not equivalent how they work. The problem that
 plugin may not find some of kotlin plugins if both approaches are used
 in the project configuration. Especially it is related to Android plugin.
 
+- Does plugin check changed files incrementally?
+
+Yes. On first run plugin will check all files in the module, on
+subsequent runs it will check only added/modified files.
+
 ## Developers
 
 ### Importing

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/TestsCommon.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/TestsCommon.kt
@@ -7,6 +7,8 @@ const val LOWEST_SUPPORTED_GRADLE_VERSION = "5.4.1"
 
 fun File.buildFile() = resolve("build.gradle")
 
+fun File.ktlintBuildDir() = resolve("build/ktlint")
+
 @Language("Groovy")
 private fun pluginsBlockWithMainPluginAndKotlinPlugin(
     kotlinPluginId: String


### PR DESCRIPTION
Using `getSources()` is not possible, because:

> Source task doesn’t support `InputChanges` out of the box, since `getSource()` always returns a new instance.

So I was advised to take a look into [JavaCompile](https://github.com/gradle/gradle/blob/16d8de50617a97fbabc1f8a92182b3b648402817/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java) task. I used it as inspiration for incremental support implementation.

Closes #231 