### PR TITLE
Disable incremental tasks api for format task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [9.1.1] - Unreleased
+### Fixed
+  - Running format task may delete source files (#302): disable incremental
+  support for format tasks. Lint tasks are still incremental.
+
 ## [9.1.0] - 2019-11-01
 ### Added
   - Support for outputColorName property (#297)

--- a/README.md
+++ b/README.md
@@ -315,8 +315,10 @@ in the project configuration. Especially it is related to Android plugin.
 
 - Does plugin check changed files incrementally?
 
-Yes. On first run plugin will check all files in the module, on
+Yes, check tasks support it. On first run task will check all files in the source set, on
 subsequent runs it will check only added/modified files.
+
+Format tasks does not check file incrementally.
 
 ## Developers
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.jlleitschuh.gradle"
-version = "9.1.0"
+version = "9.1.1-SNAPSHOT"
 
 repositories {
     google()

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -2,8 +2,12 @@ package org.jlleitschuh.gradle.ktlint
 
 import java.io.PrintWriter
 import javax.inject.Inject
+import org.gradle.api.file.FileType
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.ChangeType
+import org.gradle.work.InputChanges
 
 @Suppress("UnstableApiUsage")
 @CacheableTask
@@ -11,4 +15,22 @@ open class KtlintCheckTask @Inject constructor(
     objectFactory: ObjectFactory
 ) : BaseKtlintCheckTask(objectFactory) {
     override fun additionalConfig(): (PrintWriter) -> Unit = {}
+
+    @TaskAction
+    fun lint(inputChanges: InputChanges) {
+        project.logger.info("Executing ${if (inputChanges.isIncremental) "incrementally" else "non-incrementally"}")
+
+        val filesToLint = inputChanges
+            .getFileChanges(stableSources)
+            .asSequence()
+            .filter {
+                it.fileType != FileType.DIRECTORY &&
+                    it.changeType != ChangeType.REMOVED
+            }
+            .map { it.file }
+            .toSet()
+        project.logger.debug("Files changed: $filesToLint")
+
+        runLint(filesToLint)
+    }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintFormatTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 open class KtlintFormatTask @Inject constructor(
@@ -16,6 +17,11 @@ open class KtlintFormatTask @Inject constructor(
 ) : BaseKtlintCheckTask(objectFactory) {
     override fun additionalConfig(): (PrintWriter) -> Unit = {
         it.println("-F")
+    }
+
+    @TaskAction
+    fun format() {
+        runLint(stableSources.files)
     }
 
     /**

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -53,7 +53,7 @@ abstract class AbstractPluginTest {
 
     protected
     fun File.withFailingSources() = createSourceFile(
-        "src/main/kotlin/fail-source.kt",
+        FAIL_SOURCE_FILE,
         """
             val  foo    =     "bar"
             
@@ -77,7 +77,7 @@ abstract class AbstractPluginTest {
     )
 
     protected fun File.restoreFailingSources() {
-        val sourceFile = resolve("src/main/kotlin/fail-source.kt")
+        val sourceFile = resolve(FAIL_SOURCE_FILE)
         sourceFile.delete()
         withFailingSources()
     }
@@ -94,4 +94,8 @@ abstract class AbstractPluginTest {
     }
 
     fun File.settingsFile() = resolve("settings.gradle")
+
+    companion object {
+        const val FAIL_SOURCE_FILE = "src/main/kotlin/fail-source.kt"
+    }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -157,14 +157,15 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
     fun `Should always format again restored to pre-format state sources`() {
         projectRoot.withFailingSources()
         build(":ktlintFormat").apply {
-            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(task(":ktlintMainSourceSetFormat")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
         }
 
         projectRoot.restoreFailingSources()
 
         build(":ktlintFormat").apply {
-            assertThat(task(":ktlintMainSourceSetFormat")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(task(":ktlintMainSourceSetFormat")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
         }
+        assertThat(projectRoot.resolve(FAIL_SOURCE_FILE)).exists()
     }
 
     @Test


### PR DESCRIPTION
Disabled incremental task api for format task. As format task declares output same as input and incremental api deletes all outputs on inputs changes, this lead to files deletion on the second run.

Fixes #302 