### PR TITLE
Plugin will search for .git folder starting from the root project folder to install hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
   - Html reporter to provided reporters [#312](https://github.com/JLLeitschuh/ktlint-gradle/issues/312)
+  - Plugin will search for project `.git` folder
+    relative to gradle root project to install git hook [#284](https://github.com/JLLeitschuh/ktlint-gradle/issues/284)
 ### Changed
   - Update Gradle to `6.0.1` version
   - Update Kotlin to `1.3.60` version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Update Gradle to `6.0.1` version
   - Update Kotlin to `1.3.60` version
   - Set default ktlint version to `0.36.0`
+  - Shadow plugin dependencies into plugin jar
 ### Fixed
   - Fix `ktlintApplyToIdea` task fails when `android = true` is set [#311](https://github.com/JLLeitschuh/ktlint-gradle/issues/311)
 ### Removed

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     compileOnly(kotlin("gradle-plugin", PluginVersions.kotlin))
     compileOnly("com.android.tools.build:gradle:${PluginVersions.androidPlugin}")
     implementation("net.swiftzer.semver:semver:${PluginVersions.semver}")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:${PluginVersions.jgit}")
 
     /*
      * Do not depend upon the gradle script kotlin plugin API. IE: gradleScriptKotlinApi()

--- a/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
+++ b/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
@@ -8,4 +8,5 @@ object PluginVersions {
     val gradleWrapper = "6.0.1"
     val junit5 = "5.5.2"
     val assertJ = "3.11.1"
+    val shadow = "5.2.0"
 }

--- a/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
+++ b/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
@@ -4,6 +4,7 @@ object PluginVersions {
     val gradlePublishPlugin = "0.10.1"
     val androidPlugin = "3.5.0"
     val semver = "1.1.1"
+    val jgit = "5.6.0.201912101111-r"
     val gradleWrapper = "6.0.1"
     val junit5 = "5.5.2"
     val assertJ = "3.11.1"

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -28,16 +28,19 @@ abstract class AbstractPluginTest {
             }
         """.trimIndent()
 
-    protected
-    fun build(vararg arguments: String): BuildResult =
-        gradleRunnerFor(*arguments).forwardOutput().build()
+    protected fun build(
+        vararg arguments: String,
+        projectRoot: File = this.projectRoot
+    ): BuildResult = gradleRunnerFor(*arguments, projectRoot = projectRoot).forwardOutput().build()
 
     protected
     fun buildAndFail(vararg arguments: String): BuildResult =
-        gradleRunnerFor(*arguments).forwardOutput().buildAndFail()
+        gradleRunnerFor(arguments = *arguments).forwardOutput().buildAndFail()
 
-    protected open
-    fun gradleRunnerFor(vararg arguments: String): GradleRunner =
+    protected open fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File = this.projectRoot
+    ): GradleRunner =
         GradleRunner.create()
             .withProjectDir(projectRoot)
             .withPluginClasspath()

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/BuildCacheTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/BuildCacheTest.kt
@@ -16,8 +16,12 @@ class GradleCurrentBuildCacheTest : BuildCacheTest()
  */
 @Suppress("ClassName")
 class GradleLowestSupportedBuildCacheTest : BuildCacheTest() {
-    override fun gradleRunnerFor(vararg arguments: String): GradleRunner =
-        super.gradleRunnerFor(*arguments).withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+        super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+            .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
 }
 
 abstract class BuildCacheTest : AbstractPluginTest() {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/DisabledRulesTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/DisabledRulesTest.kt
@@ -1,5 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
+import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -16,8 +17,12 @@ class GradleCurrentCurrentDisabledRulesTest : DisabledRulesTest()
  */
 @Suppress("ClassName")
 class GradleLowestSupportedDisabledRulesTest : DisabledRulesTest() {
-    override fun gradleRunnerFor(vararg arguments: String): GradleRunner =
-        super.gradleRunnerFor(*arguments).withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+        super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+            .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
 }
 
 abstract class DisabledRulesTest : AbstractPluginTest() {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/EditorConfigTests.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/EditorConfigTests.kt
@@ -18,8 +18,12 @@ class GradleCurrentEditorConfigTest : EditorConfigTests()
 @Suppress("ClassName")
 class GradleLowestSupportedEditorConfigTest : EditorConfigTests() {
 
-    override fun gradleRunnerFor(vararg arguments: String): GradleRunner =
-        super.gradleRunnerFor(*arguments).withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+        super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+            .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
 }
 
 /**

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -2,27 +2,16 @@ package org.jlleitschuh.gradle.ktlint
 
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class GitHookTasksTest : AbstractPluginTest() {
-    @BeforeEach
-    internal fun setUp() {
-        //language=Groovy
-        projectRoot.buildFile().writeText("""
-            ${pluginsBlockWithMainPluginAndKotlinJvm()}
-
-            repositories {
-                gradlePluginPortal()
-            }
-        """.trimIndent())
-    }
-
     @Test
     internal fun `Should not add install git hook tasks to submodule`() {
+        projectRoot.setupGradleProject()
         val submoduleDir = projectRoot.resolve("some-module").also { it.mkdir() }
-        projectRoot.createGitHookFolder()
+        projectRoot.initGit()
         projectRoot.settingsFile().writeText("""
             include ":some-module"
         """.trimIndent())
@@ -41,53 +30,47 @@ class GitHookTasksTest : AbstractPluginTest() {
     }
 
     @Test
-    internal fun `Should not add install git hook tasks to root project if git folder is not exist`() {
-        buildAndFail(":$INSTALL_GIT_HOOK_CHECK_TASK").run {
-            assertThat(output).contains("Task '$INSTALL_GIT_HOOK_CHECK_TASK' not found in root project")
-        }
-        buildAndFail(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
-            assertThat(output).contains("Task '$INSTALL_GIT_HOOK_FORMAT_TASK' not found in root project")
-        }
-    }
-
-    @Test
     internal fun `Running install git hook check task should create pre-commit hook`() {
-        projectRoot.createGitHookFolder()
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
 
         build(":$INSTALL_GIT_HOOK_CHECK_TASK").run {
             assertThat(task(":$INSTALL_GIT_HOOK_CHECK_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-            assertThat(projectRoot.preCommitGitHook()).exists()
-            assertThat(projectRoot.preCommitGitHook().canExecute()).isTrue()
-            assertThat(projectRoot.preCommitGitHook().readText()).contains(CHECK_PARENT_TASK_NAME)
+            assertThat(gitDir.preCommitGitHook()).exists()
+            assertThat(gitDir.preCommitGitHook().canExecute()).isTrue()
+            assertThat(gitDir.preCommitGitHook().readText()).contains(CHECK_PARENT_TASK_NAME)
         }
     }
 
     @Test
     internal fun `Running install git hook format task should create pre-commit hook`() {
-        projectRoot.createGitHookFolder()
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
 
         build(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
             assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-            assertThat(projectRoot.preCommitGitHook()).exists()
-            assertThat(projectRoot.preCommitGitHook().canExecute()).isTrue()
-            assertThat(projectRoot.preCommitGitHook().readText()).contains(FORMAT_PARENT_TASK_NAME)
+            assertThat(gitDir.preCommitGitHook()).exists()
+            assertThat(gitDir.preCommitGitHook().canExecute()).isTrue()
+            assertThat(gitDir.preCommitGitHook().readText()).contains(FORMAT_PARENT_TASK_NAME)
         }
     }
 
     @Test
     internal fun `Should produce same hook on second run`() {
-        projectRoot.createGitHookFolder()
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
 
         build(":$INSTALL_GIT_HOOK_FORMAT_TASK")
-        val hookFileContent = projectRoot.preCommitGitHook().readText()
+        val hookFileContent = gitDir.preCommitGitHook().readText()
         build(":$INSTALL_GIT_HOOK_FORMAT_TASK")
-        assertThat(projectRoot.preCommitGitHook().readText()).isEqualTo(hookFileContent)
+        assertThat(gitDir.preCommitGitHook().readText()).isEqualTo(hookFileContent)
     }
 
     @Test
     internal fun `Should not touch already existing hooks`() {
-        projectRoot.createGitHookFolder()
-        projectRoot.preCommitGitHook().writeText("""
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
+        gitDir.preCommitGitHook().writeText("""
             $shShebang
 
             echo "test1"
@@ -100,7 +83,7 @@ class GitHookTasksTest : AbstractPluginTest() {
 
         build(":$INSTALL_GIT_HOOK_FORMAT_TASK")
 
-        val hookContent = projectRoot.preCommitGitHook().readText()
+        val hookContent = gitDir.preCommitGitHook().readText()
 
         assertThat(hookContent).startsWith("""
             $shShebang
@@ -110,7 +93,39 @@ class GitHookTasksTest : AbstractPluginTest() {
         assertThat(hookContent).endsWith("echo \"test2\"")
     }
 
+    @Test
+    internal fun `Should find git folder if Gradle project is not located in root git working dir`() {
+        val gradleRoot = projectRoot.resolve("internal/")
+        gradleRoot.mkdir()
+        gradleRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
+
+        build(":$INSTALL_GIT_HOOK_CHECK_TASK", projectRoot = gradleRoot).run {
+            assertThat(task(":$INSTALL_GIT_HOOK_CHECK_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(gitDir.preCommitGitHook()).exists()
+            assertThat(gitDir.preCommitGitHook().canExecute()).isTrue()
+            assertThat(gitDir.preCommitGitHook().readText()).contains(CHECK_PARENT_TASK_NAME)
+        }
+    }
+
+    private fun File.initGit(): File {
+        val repo = RepositoryBuilder().setWorkTree(this).setMustExist(false).build()
+        repo.create()
+        return repo.directory
+    }
+
     private fun File.preCommitGitHook(): File = gitHookFolder().resolve("pre-commit")
-    private fun File.gitHookFolder(): File = resolve(".git/hooks/")
-    private fun File.createGitHookFolder() = gitHookFolder().mkdirs()
+
+    private fun File.gitHookFolder(): File = resolve("hooks/")
+
+    private fun File.setupGradleProject() {
+        //language=Groovy
+        buildFile().writeText("""
+            ${pluginsBlockWithMainPluginAndKotlinJvm()}
+
+            repositories {
+                gradlePluginPortal()
+            }
+        """.trimIndent())
+    }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KotlinJsPluginTests.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KotlinJsPluginTests.kt
@@ -1,5 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
+import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -17,8 +18,12 @@ class GradleCurrentKotlinJsPluginTests : KotlinJsPluginTests()
 @Suppress("ClassName")
 class GradleLowestSupportedKotlinJsPluginTest : KotlinJsPluginTests() {
 
-    override fun gradleRunnerFor(vararg arguments: String): GradleRunner =
-        super.gradleRunnerFor(*arguments).withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+        super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+            .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
 }
 
 /**

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -1,5 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
+import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -14,8 +15,12 @@ class GradleCurrentKtlintPluginTest : BaseKtlintPluginTest()
 @Suppress("ClassName")
 class GradleLowestSupportedKtlintPluginTest : BaseKtlintPluginTest() {
 
-    override fun gradleRunnerFor(vararg arguments: String): GradleRunner =
-            super.gradleRunnerFor(*arguments).withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+            super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+                .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
 }
 
 abstract class BaseKtlintPluginTest : AbstractPluginTest() {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
@@ -1,5 +1,6 @@
 package org.jlleitschuh.gradle.ktlint
 
+import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -17,8 +18,12 @@ class GradleCurrentReportersTests : ReportersTest()
  */
 @Suppress("ClassName")
 class GradleLowestSupportedReportersTest : ReportersTest() {
-    override fun gradleRunnerFor(vararg arguments: String): GradleRunner =
-        super.gradleRunnerFor(*arguments).withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+        super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+            .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
 }
 
 abstract class ReportersTest : AbstractPluginTest() {


### PR DESCRIPTION
Now git tasks are always added to avoid I/O on Gradle configuration phase.

Closes #284 