### PR TITLE
Gradle Instant Execution: invocation of 'Task.project' at execution time is unsupported

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -18,7 +18,7 @@ open class KtlintCheckTask @Inject constructor(
 
     @TaskAction
     fun lint(inputChanges: InputChanges) {
-        project.logger.info("Executing ${if (inputChanges.isIncremental) "incrementally" else "non-incrementally"}")
+        logger.info("Executing ${if (inputChanges.isIncremental) "incrementally" else "non-incrementally"}")
 
         val filesToLint = inputChanges
             .getFileChanges(stableSources)
@@ -29,7 +29,7 @@ open class KtlintCheckTask @Inject constructor(
             }
             .map { it.file }
             .toSet()
-        project.logger.debug("Files changed: $filesToLint")
+        logger.debug("Files changed: $filesToLint")
 
         runLint(filesToLint)
     }


### PR DESCRIPTION
Running a project with the flag `-Dorg.gradle.unsafe.instant-execution=true` results in a failure because:
> task `:ktlintMainSourceSetCheck` of type `org.jlleitschuh.gradle.ktlint.KtlintCheckTask`: invocation of 'Task.project' at execution time is unsupported.