### PR TITLE
Set default ktlint version to 0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
   - Check pre-commit hook will not add partially committed files to git commit [#330](https://github.com/JLLeitschuh/ktlint-gradle/issues/330)
   - Update Gradle to `6.2.1` version
-  - Update Android Gradle plugin to `3.6.0` version
+  - Update Android Gradle plugin to `3.6.3` version
+  - Set default ktlint version to `0.37.1`
 ### Fixed
   - ?
 ### Deleted

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ This repository provides following examples how to setup this plugin:
 - [kotlin-js](/samples/kotlin-js) - applies plugin to kotlin js project
 - [kotlin-ks](/samples/kotlin-ks) - applies plugin to plain Kotlin project that uses Kotlin DSL in `build.gradle.kts` files
 - [kotlin-multiplatform-common](/samples/kotlin-multiplatform-common) - applies plugin to Kotlin common multiplatform module
-- [kotlin-multiplatform-js](/samples/kotlin-multiplatform-js) - applies plugin to Kotlin Javascript multiplatform module
+- [kotlin-multiplatform-js](/samples/kotlin-multiplatform-js) - applies plugin to Kotlin JavaScript multiplatform module
 - [kotlin-multiplatform-jvm](/samples/kotlin-multiplatform-jvm) - applies plugin to Kotlin JVM multiplatform module
 - [kotlin-rulesets-using](/samples/kotlin-rulesets-using) - adds custom [example](/samples/kotlin-ruleset-creating) ruleset
 - [kotlin-reporter-using](/samples/kotlin-reporter-using) - adds custom [example](/samples/kotlin-reporter-creating) reporter 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -154,7 +154,7 @@ fun setupPublishingEnvironment() {
         if (key != null) {
             System.setProperty(githubProperty, key)
         } else {
-            logger.warn("Github key was null")
+            logger.warn("GitHub key was null")
         }
     }
 }

--- a/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
+++ b/plugin/buildSrc/src/main/kotlin/PluginDependencies.kt
@@ -1,8 +1,8 @@
 object PluginVersions {
-    val kotlin = "1.3.60"
+    val kotlin = "1.3.72"
     val ktlintPlugin = "9.1.1"
     val gradlePublishPlugin = "0.10.1"
-    val androidPlugin = "3.6.0"
+    val androidPlugin = "3.6.3"
     val semver = "1.1.1"
     val jgit = "5.6.0.201912101111-r"
     val gradleWrapper = "6.2.1"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -33,7 +33,7 @@ internal constructor(
     /**
      * The version of ktlint to use.
      */
-    val version: Property<String> = objectFactory.property { set("0.36.0") }
+    val version: Property<String> = objectFactory.property { set("0.37.1") }
 
     /**
      * Enable verbose mode.

--- a/samples/android-app/src/main/java/org/jlleitschuh/gradle/ktlint/android/ItemDetailActivity.kt
+++ b/samples/android-app/src/main/java/org/jlleitschuh/gradle/ktlint/android/ItemDetailActivity.kt
@@ -23,7 +23,7 @@ class ItemDetailActivity : AppCompatActivity() {
 
         fab.setOnClickListener { view ->
             Snackbar.make(view, "Replace with your own detail action", Snackbar.LENGTH_LONG)
-                    .setAction("Action", null).show()
+                .setAction("Action", null).show()
         }
 
         // Show the Up button in the action bar.
@@ -42,28 +42,30 @@ class ItemDetailActivity : AppCompatActivity() {
             // Create the detail fragment and add it to the activity
             // using a fragment transaction.
             val arguments = Bundle()
-            arguments.putString(ItemDetailFragment.ARG_ITEM_ID,
-                    intent.getStringExtra(ItemDetailFragment.ARG_ITEM_ID))
+            arguments.putString(
+                ItemDetailFragment.ARG_ITEM_ID,
+                intent.getStringExtra(ItemDetailFragment.ARG_ITEM_ID)
+            )
             val fragment = ItemDetailFragment()
             fragment.arguments = arguments
             supportFragmentManager.beginTransaction()
-                    .add(R.id.item_detail_container, fragment)
-                    .commit()
+                .add(R.id.item_detail_container, fragment)
+                .commit()
         }
     }
 
     override fun onOptionsItemSelected(item: MenuItem) =
-            when (item.itemId) {
-                android.R.id.home -> {
-                    // This ID represents the Home or Up button. In the case of this
-                    // activity, the Up button is shown. For
-                    // more details, see the Navigation pattern on Android Design:
-                    //
-                    // http://developer.android.com/design/patterns/navigation.html#up-vs-back
+        when (item.itemId) {
+            android.R.id.home -> {
+                // This ID represents the Home or Up button. In the case of this
+                // activity, the Up button is shown. For
+                // more details, see the Navigation pattern on Android Design:
+                //
+                // http://developer.android.com/design/patterns/navigation.html#up-vs-back
 
-                    navigateUpTo(Intent(this, ItemListActivity::class.java))
-                    true
-                }
-                else -> super.onOptionsItemSelected(item)
+                navigateUpTo(Intent(this, ItemListActivity::class.java))
+                true
             }
+            else -> super.onOptionsItemSelected(item)
+        }
 }

--- a/samples/android-app/src/main/java/org/jlleitschuh/gradle/ktlint/android/ItemListActivity.kt
+++ b/samples/android-app/src/main/java/org/jlleitschuh/gradle/ktlint/android/ItemListActivity.kt
@@ -43,7 +43,7 @@ class ItemListActivity : AppCompatActivity() {
 
         fab.setOnClickListener { view ->
             Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
-                    .setAction("Action", null).show()
+                .setAction("Action", null).show()
         }
 
         if (item_detail_container != null) {
@@ -78,9 +78,9 @@ class ItemListActivity : AppCompatActivity() {
                         arguments?.putString(ItemDetailFragment.ARG_ITEM_ID, item.id)
                     }
                     mParentActivity.supportFragmentManager
-                            .beginTransaction()
-                            .replace(R.id.item_detail_container, fragment)
-                            .commit()
+                        .beginTransaction()
+                        .replace(R.id.item_detail_container, fragment)
+                        .commit()
                 } else {
                     val intent = Intent(v.context, ItemDetailActivity::class.java).apply {
                         putExtra(ItemDetailFragment.ARG_ITEM_ID, item.id)
@@ -92,7 +92,7 @@ class ItemListActivity : AppCompatActivity() {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
             val view = LayoutInflater.from(parent.context)
-                    .inflate(R.layout.item_list_content, parent, false)
+                .inflate(R.layout.item_list_content, parent, false)
             return ViewHolder(view)
         }
 

--- a/samples/kotlin-multiplatform-js/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/multiplatform/Sample.kt
+++ b/samples/kotlin-multiplatform-js/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/multiplatform/Sample.kt
@@ -1,10 +1,10 @@
 package org.jlleitschuh.gradle.ktlint.sample.kotlin.multiplatform
 
 /**
- * Javascript platform implementation of demo class.
+ * JavaScript platform implementation of demo class.
  */
 actual class Sample {
     actual fun doPlatformThing(): CharSequence {
-        return "Hello from Javascript platform"
+        return "Hello from JavaScript platform"
     }
 }

--- a/samples/kotlin-rulesets-creating/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/NoVarRule.kt
+++ b/samples/kotlin-rulesets-creating/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/kotlin/NoVarRule.kt
@@ -13,7 +13,8 @@ class NoVarRule : Rule("no-var") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node is LeafPsiElement && node.textMatches("var") &&
-                getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null) {
+            getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null
+        ) {
             emit(node.startOffset, "Unexpected var, use val instead", false)
         }
     }


### PR DESCRIPTION
- Use ktlint `0.37.1` by default, which required minor formatting fixes in the android sample app
- Patch updated the Android Gradle plugin from `3.6.0` to `3.6.3` (including the bundled kotlin dependency)
- A couple of minor typo fixes (in a separate commit).