### PR TITLE
Skip ktlint and report up-to-date if incremental task run contains only removed files

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintCheckTask.kt
@@ -31,8 +31,14 @@ open class KtlintCheckTask @Inject constructor(
             }
             .map { it.file }
             .toSet()
-        logger.debug("Files changed: $filesToLint")
 
-        runLint(filesToLint)
+        if (filesToLint.isEmpty()) {
+            didWork = false
+            logger.info("No ${ChangeType.ADDED} or ${ChangeType.MODIFIED} files that need to be linted")
+        } else {
+            logger.debug("Files changed: $filesToLint")
+
+            runLint(filesToLint)
+        }
     }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/AbstractPluginTest.kt
@@ -97,6 +97,12 @@ abstract class AbstractPluginTest {
         sourceFile.writeText(contents)
     }
 
+    protected
+    fun File.removeSourceFile(sourceFilePath: String) {
+        val sourceFile = resolve(sourceFilePath)
+        sourceFile.delete()
+    }
+
     fun File.settingsFile() = resolve("settings.gradle")
 
     companion object {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -411,4 +411,39 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
             assertThat(args).doesNotContain(initialSourceFile)
         }
     }
+
+    @Test
+    internal fun `Should do nothing when there are no eligible incremental updates`() {
+        val passingContents =
+            """
+            val foo = "bar"
+
+            """.trimIndent()
+
+        val failingContents =
+            """
+            val foo="bar"
+
+            """.trimIndent()
+
+        val initialSourceFile = "src/main/kotlin/initial.kt"
+        projectRoot.createSourceFile(initialSourceFile, passingContents)
+
+        val additionalSourceFile = "src/main/kotlin/another-file.kt"
+        projectRoot.createSourceFile(additionalSourceFile, passingContents)
+
+        val testSourceFile = "src/test/kotlin/another-file.kt"
+        projectRoot.createSourceFile(testSourceFile, failingContents)
+
+        build(":ktlintMainSourceSetCheck").apply {
+            assertThat(task(":ktlintMainSourceSetCheck")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        }
+
+        // Removing a source file will cause the task to run, but the only incremental change will
+        // be REMOVED, which does need to call ktlint
+        projectRoot.removeSourceFile(initialSourceFile)
+        build(":ktlintMainSourceSetCheck").apply {
+            assertThat(task(":ktlintMainSourceSetCheck")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+        }
+    }
 }


### PR DESCRIPTION
Fixed #385 

Test and main code are in two separate commits to make it easier to demonstrate the problem. I would suggest squashing at merge.