### PR TITLE
Fix tasks may not be cacheable due to overlapping outputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - ?
 ### Changed
   - Updated Gradle to `6.6.1` version
+  - Each task will output reports into subdirectory inside `build/reports/ktlint` directory to fix non-working caching [#379](https://github.com/JLLeitschuh/ktlint-gradle/issues/379)
 ### Fixed
   - ?
 ### Deleted

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ It is possible also to define different from default output directory for genera
 
 ```groovy
 tasks.withType(org.jlleitschuh.gradle.ktlint.KtlintCheckTask) {
-    reporterOutputDir = project.layout.buildDirectory.dir("other/location")
+    reporterOutputDir = project.layout.buildDirectory.dir("other/location/$name")
 }
 ```
 </details>
@@ -303,7 +303,7 @@ tasks.withType(org.jlleitschuh.gradle.ktlint.KtlintCheckTask) {
 ```kotlin
 tasks.withType<org.jlleitschuh.gradle.ktlint.KtlintCheckTask>() {
     reporterOutputDir.set(
-        project.layout.buildDirectory.dir("other/location")
+        project.layout.buildDirectory.dir("other/location/$name")
     )
 }
 ```

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -279,11 +279,13 @@ abstract class BaseKtlintCheckTask(
     /**
      * Base location of ktlint generated reports.
      *
-     * Default is "${project.buildDir}/reports/ktlint".
+     * Default is "${project.buildDir}/reports/ktlint/$name".
+     *
+     * **Note**: should be unique per task, otherwise task caching will not work.
      */
     @get:OutputDirectory
     val reporterOutputDir: DirectoryProperty = objectFactory.directoryProperty().convention(
-        project.layout.buildDirectory.dir("reports/ktlint")
+        project.layout.buildDirectory.dir("reports/ktlint/$name")
     )
 
     /**

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/BuildCacheTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/BuildCacheTest.kt
@@ -37,11 +37,13 @@ abstract class BuildCacheTest : AbstractPluginTest() {
         createRunner(originalRoot)
             .build().apply {
                 assertThat(task(":ktlintMainSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                assertThat(task(":ktlintTestSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
             }
 
         createRunner(relocatedRoot)
             .build().apply {
                 assertThat(task(":ktlintMainSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
+                assertThat(task(":ktlintTestSourceSetCheck")!!.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
             }
     }
 
@@ -106,6 +108,13 @@ abstract class BuildCacheTest : AbstractPluginTest() {
     ) {
         listOf(originalRoot, relocatedRoot).forEach {
             it.withCleanSources()
+            it.createSourceFile(
+                "src/test/kotlin/Test.kt",
+                """
+                class Test
+            
+                """.trimIndent()
+            )
             it.buildFile().writeText(
                 """
                     ${pluginsBlockWithMainPluginAndKotlinJvm()}

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
@@ -212,7 +212,7 @@ abstract class ReportersTest : AbstractPluginTest() {
             }
 
             tasks.withType(org.jlleitschuh.gradle.ktlint.KtlintCheckTask.class) {
-                reporterOutputDir = project.layout.buildDirectory.dir("$newLocation")
+                reporterOutputDir = project.layout.buildDirectory.dir("$newLocation/${'$'}name")
             }
             """.trimIndent()
         )
@@ -245,5 +245,7 @@ abstract class ReportersTest : AbstractPluginTest() {
     private fun reportLocation(
         reportsLocation: String,
         reportFileExtension: String
-    ) = projectRoot.resolve("$reportsLocation/ktlintMainSourceSetCheck.$reportFileExtension")
+    ) = projectRoot.resolve(
+        "$reportsLocation/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.$reportFileExtension"
+    )
 }


### PR DESCRIPTION
Fixes #379 