### PR TITLE
Fix running checks on windows does not fail on errors.

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -4,7 +4,10 @@ on: [pull_request, push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
       - name: set up JDK 1.8
@@ -59,7 +62,10 @@ jobs:
         run: ./gradlew addKtlintCheckGitPreCommitHook --no-daemon && checkbashisms .git/hooks/pre-commit
 
   check_samples:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     needs: build
     steps:
       - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [9.4.1] - 2020.10.05
+### Fixed
+  - Plugin now correctly validates files on Windows OS [#399](https://github.com/JLLeitschuh/ktlint-gradle/issues/399)
+
 ## [9.4.0] - 2020.09.06
 ### Changed
   - Updated Gradle to `6.6.1` version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Provides a convenient wrapper plugin over the [ktlint](https://github.com/pinterest/ktlint) project.**
 
-Latest plugin version: [9.4.0](/CHANGELOG.md#940---2020-09-06)
+Latest plugin version: [9.4.1](/CHANGELOG.md#941---2020-10-05)
 
 [![Join the chat at https://kotlinlang.slack.com](https://img.shields.io/badge/slack-@kotlinlang/ktlint-yellow.svg?logo=slack)](https://kotlinlang.slack.com/messages/CKS3XG0LS)
 [![Build Status](https://travis-ci.org/JLLeitschuh/ktlint-gradle.svg?branch=master)](https://travis-ci.org/JLLeitschuh/ktlint-gradle)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 val pluginGroup = "org.jlleitschuh.gradle"
 group = pluginGroup
-version = "9.4.0"
+version = "9.4.1"
 
 repositories {
     google()

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -207,7 +207,8 @@ abstract class BaseKtlintCheckTask(
                 }
             additionalConfig(argsWriter)
             filesToCheck.forEach {
-                argsWriter.println("\"${it.toRelativeFile()}\"")
+                val filePath = it.toRelativeFile().path.replace("\\", "\\\\")
+                argsWriter.println("\"$filePath\"")
             }
         }
         return argsConfigFile

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -242,7 +242,7 @@ abstract class BaseKtlintCheckTask(
         ) {
             logger.warn(
                 "You are using ktlint version ${ktlintVersion.get()} that has the security vulnerability " +
-                    "'CWE-494: Download of Code Without Integrity Check'.\n" +
+                    "'CWE-494: Download of Code Without Integrity Check'.${System.lineSeparator()}" +
                     "Consider upgrading to versions consider upgrading to versions >= 0.30.0"
             )
         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -77,7 +77,7 @@ private tailrec fun searchEditorConfigFiles(
     }
 }
 
-private val editorConfigRootRegex = "^root\\s?=\\s?true\\n".toRegex()
+private val editorConfigRootRegex = "^root\\s?=\\s?true\\R".toRegex()
 
 private fun Path.isRootEditorConfig(): Boolean {
     val asFile = toFile()

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -404,11 +404,18 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
             """.trimIndent()
         )
 
+        // TODO: Add better approach to different file paths on different OS
+        fun String.updatePathForWindows() = if (System.getProperty("os.name").contains("Windows")) {
+            replace("/", "\\\\")
+        } else {
+            this
+        }
+
         build(":ktlintCheck").apply {
             assertThat(task(":ktlintMainSourceSetCheck")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
             val args = projectRoot.ktlintBuildDir().resolve("ktlintMainSourceSetCheck.args").readText()
-            assertThat(args).contains(additionalSourceFile)
-            assertThat(args).doesNotContain(initialSourceFile)
+            assertThat(args).contains(additionalSourceFile.updatePathForWindows())
+            assertThat(args).doesNotContain(initialSourceFile.updatePathForWindows())
         }
     }
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -207,8 +207,8 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
 
         build(":dependencies").apply {
             assertThat(output).contains(
-                "$KTLINT_CONFIGURATION_NAME - $KTLINT_CONFIGURATION_DESCRIPTION\n" +
-                    "\\--- com.github.shyiko:ktlint:0.26.0\n"
+                "$KTLINT_CONFIGURATION_NAME - $KTLINT_CONFIGURATION_DESCRIPTION${System.lineSeparator()}" +
+                    "\\--- com.github.shyiko:ktlint:0.26.0${System.lineSeparator()}"
             )
         }
     }
@@ -226,8 +226,8 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
 
         build(":dependencies").apply {
             assertThat(output).contains(
-                "$KTLINT_CONFIGURATION_NAME - $KTLINT_CONFIGURATION_DESCRIPTION\n" +
-                    "\\--- com.pinterest:ktlint:0.32.0\n"
+                "$KTLINT_CONFIGURATION_NAME - $KTLINT_CONFIGURATION_DESCRIPTION${System.lineSeparator()}" +
+                    "\\--- com.pinterest:ktlint:0.32.0${System.lineSeparator()}"
             )
         }
     }


### PR DESCRIPTION
- Enable running plugin tests on windows os via Github actions
- Fix Picoli [requires](https://picocli.info/#AtFiles) double `\\` in argument files
- Fix failing tests

Fixes #399 
Fixes #232 