### PR TITLE
Fixes Gradle 7.0 deprecation warning for reporterOutputDir

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/BaseKtlintCheckTask.kt
@@ -267,13 +267,11 @@ abstract class BaseKtlintCheckTask(
     private fun ReporterType.isAvailable() =
         SemVer.parse(ktlintVersion.get()) >= availableSinceVersion
 
-    private fun ReporterType.getOutputFile() = reporterOutputDir.map {
-        it.file("${this@BaseKtlintCheckTask.name}.$fileExtension")
-    }
+    private fun ReporterType.getOutputFile() =
+        reporterOutputDir.get().file("${this@BaseKtlintCheckTask.name}.$fileExtension")
 
-    private fun CustomReporter.getOutputFile() = reporterOutputDir.map {
-        it.file("${this@BaseKtlintCheckTask.name}.$fileExtension")
-    }
+    private fun CustomReporter.getOutputFile() =
+        reporterOutputDir.get().file("${this@BaseKtlintCheckTask.name}.$fileExtension")
 
     private fun File.toRelativeFile(): File = relativeTo(projectLayout.projectDirectory.asFile)
 


### PR DESCRIPTION
Fixes the following deprecation warning: 

![image](https://user-images.githubusercontent.com/1133099/103664682-d3033180-4f72-11eb-88e1-891957637415.png)
