### PR TITLE
Requirement for GIT Pre-Commit Hooks Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ rules using ktlint.
 
 For all Gradle versions:
 
-Use the same `buildscript` logic as [above](#simple-setup), but with this instead of the above suggested `apply` line.
+Use the same `buildscript` logic as [above](#simple-setup), but with this instead of the above suggested `apply` line. If you also want the GIT pre-commit gradle tasks, keep both `apply` variations.
 
 ```groovy
 apply plugin: "org.jlleitschuh.gradle.ktlint-idea"


### PR DESCRIPTION
Made it more obvious that both plugins are needed to have the extra gradle tasks related to Idea and GIT