### PR TITLE
Reset KtLint internal cache on .editorconfig files change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Plugin fails to apply on non-Kotlin projects ([#443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443))
   - Pre-commit hook adds entire file to commit when only part of the file was indexed ([#470](https://github.com/JLLeitschuh/ktlint-gradle/pull/470))
   - Pre-commit hook doesn't format files that have been renamed ([#471](https://github.com/JLLeitschuh/ktlint-gradle/pull/471))
+  - Reset KtLint internal caches on any `.editorconfig` files changes ([#456](https://github.com/JLLeitschuh/ktlint-gradle/issues/456))
 ### Removed
   - ?
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
@@ -49,10 +49,14 @@ abstract class BaseKtLintCheckTask @Inject constructor(
     @Suppress("unused")
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
-    internal val editorConfigFiles: FileCollection by lazy(LazyThreadSafetyMode.NONE) {
-        // Gradle will lazy evaluate this task input only on task execution
-        getEditorConfigFiles(project, additionalEditorconfigFile)
-    }
+    internal val editorConfigFiles: FileCollection = objectFactory.fileCollection().from(
+        {
+            getEditorConfigFiles(
+                projectLayout.projectDirectory.asFile.toPath(),
+                additionalEditorconfigFile
+            )
+        }
+    )
 
     @get:Input
     internal abstract val ktLintVersion: Property<String>

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileType
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -21,6 +22,9 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
+import org.gradle.work.ChangeType
+import org.gradle.work.Incremental
+import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
 import org.jlleitschuh.gradle.ktlint.FILTER_INCLUDE_PROPERTY_NAME
 import org.jlleitschuh.gradle.ktlint.KOTLIN_EXTENSIONS
@@ -30,7 +34,6 @@ import org.jlleitschuh.gradle.ktlint.intermediateResultsBuildDir
 import org.jlleitschuh.gradle.ktlint.property
 import org.jlleitschuh.gradle.ktlint.worker.KtLintWorkAction
 import java.io.File
-import java.util.concurrent.Callable
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
@@ -46,7 +49,7 @@ abstract class BaseKtLintCheckTask @Inject constructor(
     @get:Internal
     internal abstract val additionalEditorconfigFile: RegularFileProperty
 
-    @Suppress("unused")
+    @get:Incremental
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
     internal val editorConfigFiles: FileCollection = objectFactory.fileCollection().from(
@@ -103,9 +106,7 @@ abstract class BaseKtLintCheckTask @Inject constructor(
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
     internal val stableSources: FileCollection = project.files(
-        Callable {
-            return@Callable source
-        }
+        { source }
     )
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -120,10 +121,27 @@ abstract class BaseKtLintCheckTask @Inject constructor(
         )
 
     protected fun runLint(
-        filesToCheck: Set<File>,
+        inputChanges: InputChanges?,
         formatSources: Boolean,
     ) {
         checkDisabledRulesSupportedKtLintVersion()
+
+        val editorConfigUpdated = wasEditorConfigFilesUpdated(inputChanges)
+        val filesToCheck = if (formatSources || editorConfigUpdated || inputChanges == null) {
+            stableSources.files
+        } else {
+            getChangedSources(inputChanges)
+        }
+
+        logger.info("Executing ${if (inputChanges?.isIncremental == true) "incrementally" else "non-incrementally"}")
+        logger.info("Editorconfig files were changed: $editorConfigUpdated")
+        if (filesToCheck.isEmpty()) {
+            logger.info("Skipping. No files to lint")
+            didWork = false
+            return
+        } else {
+            logger.debug("Linting files: ${filesToCheck.joinToString()}")
+        }
 
         // Process isolation is used here to run KtLint in a separate java process.
         // This allows to better isolate work actions from different projects tasks between each other
@@ -145,8 +163,27 @@ abstract class BaseKtLintCheckTask @Inject constructor(
             params.formatSource.set(formatSources)
             params.discoveredErrorsFile.set(discoveredErrors)
             params.ktLintVersion.set(ktLintVersion)
+            params.editorconfigFilesWereChanged.set(editorConfigUpdated)
         }
     }
+
+    private fun wasEditorConfigFilesUpdated(
+        inputChanges: InputChanges?
+    ) = inputChanges != null &&
+        inputChanges.isIncremental &&
+        !inputChanges.getFileChanges(editorConfigFiles).none()
+
+    private fun getChangedSources(
+        inputChanges: InputChanges
+    ): Set<File> = inputChanges
+        .getFileChanges(stableSources)
+        .asSequence()
+        .filter {
+            it.fileType != FileType.DIRECTORY &&
+                it.changeType != ChangeType.REMOVED
+        }
+        .map { it.file }
+        .toSet()
 
     private fun checkDisabledRulesSupportedKtLintVersion() {
         if (disabledRules.get().isNotEmpty() &&

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintCheckTask.kt
@@ -1,11 +1,9 @@
 package org.jlleitschuh.gradle.ktlint.tasks
 
-import org.gradle.api.file.FileType
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.TaskAction
-import org.gradle.work.ChangeType
 import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
@@ -24,26 +22,7 @@ abstract class KtLintCheckTask @Inject constructor(
 
     @TaskAction
     fun lint(inputChanges: InputChanges) {
-        logger.info("Executing ${if (inputChanges.isIncremental) "incrementally" else "non-incrementally"}")
-
-        val filesToLint = inputChanges
-            .getFileChanges(stableSources)
-            .asSequence()
-            .filter {
-                it.fileType != FileType.DIRECTORY &&
-                    it.changeType != ChangeType.REMOVED
-            }
-            .map { it.file }
-            .toSet()
-
-        if (filesToLint.isEmpty()) {
-            didWork = false
-            logger.info("No ${ChangeType.ADDED} or ${ChangeType.MODIFIED} files that need to be linted")
-        } else {
-            logger.debug("Files changed: $filesToLint")
-
-            runLint(filesToLint, false)
-        }
+        runLint(inputChanges, false)
     }
 
     internal companion object {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintFormatTask.kt
@@ -22,7 +22,7 @@ abstract class KtLintFormatTask @Inject constructor(
 
     @TaskAction
     fun format() {
-        runLint(stableSources.files, true)
+        runLint(null, true)
     }
 
     /**

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.core.RuleSetProvider
 import net.swiftzer.semver.SemVer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkAction
@@ -15,6 +16,9 @@ import java.util.ServiceLoader
 
 @Suppress("UnstableApiUsage")
 abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParameters> {
+
+    private val logger = Logging.getLogger("ktlint-worker")
+
     override fun execute() {
         val ruleSets = loadRuleSetsAndFilterThem(
             parameters.enableExperimental.getOrElse(false),
@@ -29,6 +33,8 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
         val userData = generateUserData()
         val debug = parameters.debug.get()
         val formatSource = parameters.formatSource.getOrElse(false)
+
+        resetEditorconfigCache()
 
         val result = mutableListOf<LintErrorResult>()
 
@@ -75,6 +81,14 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
             )
     }
 
+    private fun resetEditorconfigCache() {
+        if (parameters.editorconfigFilesWereChanged.get()) {
+            logger.info("Resetting KtLint caches")
+            // Calling trimMemory() will also reset internal loaded `.editorconfig` cache
+            KtLint.trimMemory()
+        }
+    }
+
     private fun generateUserData(): Map<String, String> {
         val userData = mutableMapOf(
             "android" to parameters.android.get().toString()
@@ -116,5 +130,6 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
         val formatSource: Property<Boolean>
         val discoveredErrorsFile: RegularFileProperty
         val ktLintVersion: Property<String>
+        val editorconfigFilesWereChanged: Property<Boolean>
     }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/EditorConfigTests.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/EditorConfigTests.kt
@@ -75,9 +75,10 @@ abstract class EditorConfigTests : AbstractPluginTest() {
             assertThat(task(":$lintTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
         }
 
-        projectRoot.modifyEditorconfigFile(100)
-        build(CHECK_PARENT_TASK_NAME).apply {
+        projectRoot.modifyEditorconfigFile(10)
+        buildAndFail(CHECK_PARENT_TASK_NAME).apply {
             assertThat(task(":$lintTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
         }
     }
 
@@ -92,11 +93,12 @@ abstract class EditorConfigTests : AbstractPluginTest() {
         }
 
         projectRoot.modifyEditorconfigFile(
-            maxLineLength = 100,
+            maxLineLength = 10,
             filePath = additionalConfigPath
         )
-        build(CHECK_PARENT_TASK_NAME).apply {
+        buildAndFail(CHECK_PARENT_TASK_NAME).apply {
             assertThat(task(":$lintTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
         }
     }
 
@@ -147,13 +149,14 @@ abstract class EditorConfigTests : AbstractPluginTest() {
                 assertThat(task(":test:module1:$lintTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
             }
 
-        projectWithModulesLocation.modifyEditorconfigFile(100)
+        projectWithModulesLocation.modifyEditorconfigFile(10)
 
         gradleRunner
             .withArguments(":test:module1:$CHECK_PARENT_TASK_NAME")
             .forwardOutput()
-            .build().apply {
+            .buildAndFail().apply {
                 assertThat(task(":test:module1:$lintTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                assertThat(task(":test:module1:$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
             }
     }
 


### PR DESCRIPTION
Reset internal KtLint caches on any `.editorconfig` files change, so KtLint will repopulate caches and takes into account new content.

Additionally:
- slightly optimize `.editorconfig` files locate logic
- re-run KtLint on all sources on any `.editorconfig` files change, as change may affect rules behaviour

Fixes #456 