### PR TITLE
git hook: don't commit whole file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Updated default KtLint version to `0.41.0`
 ### Fixed
   - Plugin fails to apply on non-Kotlin projects ([#443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443))
+  - Pre-commit hook adds entire file to commit when only part of the file was indexed ([#470](https://github.com/JLLeitschuh/ktlint-gradle/pull/470))
 ### Removed
   - ?
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -74,11 +74,16 @@ internal fun generateGitHook(
 
     echo "Running ktlint over these files:"
     echo "${'$'}CHANGED_FILES"
-
+    
+    git stash push --keep-index
+    
     ${generateGradleCommand(taskName, gradleRootDirPrefix)}
 
     echo "Completed ktlint run."
     ${postCheck(shouldUpdateCommit)}
+    
+    git stash pop
+    
     echo "Completed ktlint hook."
 
     """.trimIndent()

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -138,6 +138,30 @@ class GitHookTasksTest : AbstractPluginTest() {
         }
     }
 
+    @Test
+    internal fun `Format hook should not add non-indexed code to the commit`() {
+        // TODO: This test doesn't run git or verify that only indexed code is committed,
+        //  only that the hook contains the correct commands.
+        //  Ideally an end to end test case would do something like:
+        //
+        //  echo "val a  = 1" > test.kt
+        //  git add test.kt
+        //  echo "val b  = 2" >> test.kt
+        //  git commit -m test
+        //  assert that commit equals "val a = 1"
+        //  assert that test.kt equals "val a = 1\nval b  = 2"
+
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
+
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
+            assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            val hookText = gitDir.preCommitGitHook().readText()
+            assertThat(hookText).contains("git stash push")
+            assertThat(hookText).contains("git stash pop")
+        }
+    }
+
     private fun File.initGit(): File {
         val repo = RepositoryBuilder().setWorkTree(this).setMustExist(false).build()
         repo.create()


### PR DESCRIPTION
When you commit part of a file the current git hook will change your commit to being the entire file.

This pr stashes the worktree before fmt, and unstashed before finished