### PR TITLE
git hook: format renamed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
   - Plugin fails to apply on non-Kotlin projects ([#443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443))
   - Pre-commit hook adds entire file to commit when only part of the file was indexed ([#470](https://github.com/JLLeitschuh/ktlint-gradle/pull/470))
+  - Pre-commit hook doesn't format files that have been renamed ([#471](https://github.com/JLLeitschuh/ktlint-gradle/pull/471))
 ### Removed
   - ?
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -57,6 +57,8 @@ private fun postCheck(
     ""
 }
 
+internal const val NF = "\$NF"
+
 @Language("Sh")
 internal fun generateGitHook(
     taskName: String,
@@ -65,7 +67,7 @@ internal fun generateGitHook(
 ) =
     """
 
-    CHANGED_FILES="${'$'}(${generateGitCommand(gradleRootDirPrefix)} | awk '$1 != "D" && $2 ~ /\.kts|\.kt/ { print $2}')"
+    CHANGED_FILES="${'$'}(${generateGitCommand(gradleRootDirPrefix)} | awk '$1 != "D" && $NF ~ /\.kts?$/ { print $NF }')"
 
     if [ -z "${'$'}CHANGED_FILES" ]; then
         echo "No Kotlin staged files."

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -162,6 +162,28 @@ class GitHookTasksTest : AbstractPluginTest() {
         }
     }
 
+    @Test
+    internal fun `Format hook should format files when they are renamed`() {
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
+
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
+            assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(gitDir.preCommitGitHook().readText()).contains("""{ print $NF }""")
+        }
+    }
+
+    @Test
+    internal fun `Format hook should only format files that end with kt or kts`() {
+        projectRoot.setupGradleProject()
+        val gitDir = projectRoot.initGit()
+
+        build(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
+            assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(gitDir.preCommitGitHook().readText()).contains("""/\.kts?$/""")
+        }
+    }
+
     private fun File.initGit(): File {
         val repo = RepositoryBuilder().setWorkTree(this).setMustExist(false).build()
         repo.create()


### PR DESCRIPTION
When a file is renamed git diff will return the status, old and new name. so `$2` will return the old name, `$NF` will return the last field in the string, the new name.