### PR TITLE
Add KtLint baseline support

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -52,6 +52,12 @@ jobs:
             ${{ runner.os }}-gradle-wrapper-
       - name: Build plugin
         run: ./plugin/gradlew -p ./plugin build --no-daemon
+      - name: Save test results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-results
+          path: plugin/build/reports/tests/test/
       - name: Check plugin codestyle
         run: ./plugin/gradlew -p ./plugin ktlintCheck --no-daemon
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [10.1.0-SNAPSHOT] Unreleased
 ### Added
-  - ?
+  - Baseline support ([#414](https://github.com/JLLeitschuh/ktlint-gradle/issues/414))
+
+    Limitations:
+    - Format tasks ignore baseline
+    - One baseline file per-Gradle project (module)
+    
 ### Changed
   - Updated Gradle to `6.8.3` version
   - Updated default KtLint version to `0.41.0`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The assumption being that you would not want to lint code you weren't compiling.
     - [Simple setup](#simple-setup)
     - [Using new plugin API](#using-new-plugin-api)
     - [How to apply to all subprojects](#applying-to-subprojects)
+    - [Baseline support](#baseline-support)
     - [Testing KtLint snapshots](#testing-ktlint-snapshots)
   - [Intellij IDEA plugin](#intellij-idea-only-plugin)
     - [Simple setup](#idea-plugin-simple-setup)
@@ -173,6 +174,12 @@ subprojects {
 ```
 </details>
 
+#### Baseline support
+
+Plugin supports KtLint baseline with following limitations:
+- Format tasks ignore baseline. See [#1072](https://github.com/pinterest/ktlint/issues/1072) KtLint issue for more details.
+- One baseline file is generated per one Gradle project (module).
+
 #### Testing KtLint snapshots
 
 To test KtLint snapshots add following configuration into project build script (latest KtLint snapshot version name
@@ -261,6 +268,7 @@ ktlint {
     enableExperimentalRules = true
     additionalEditorconfigFile = file("/some/additional/.editorconfig")
     disabledRules = ["final-newline"]
+    baseline = file("my-project-ktlint-baseline.xml")
     reporters {
         reporter "plain"
         reporter "checkstyle"
@@ -311,6 +319,7 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
     enableExperimentalRules.set(true)
     additionalEditorconfigFile.set(file("/some/additional/.editorconfig"))
     disabledRules.set(setOf("final-newline"))
+    baseline.set(file("my-project-ktlint-baseline.xml"))
     reporters {
         reporter(ReporterType.PLAIN)
         reporter(ReporterType.CHECKSTYLE)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -108,13 +108,13 @@ internal constructor(
     /**
      * Baseline file location.
      *
-     * Default location is `<projectDir>/ktlintBaseline.xml`.
+     * Default location is `<projectDir>/config/ktlint/baseline.xml`.
      *
      * @since KtLint `0.41.0`
      */
     val baseline: RegularFileProperty = objectFactory.fileProperty()
         .convention(
-            projectLayout.projectDirectory.file("ktlintBaseline.xml")
+            projectLayout.projectDirectory.dir("config").dir("ktlint").file("baseline.xml")
         )
 
     private val kscriptExtension = KScriptExtension(kotlinScriptAdditionalPathApplier)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -4,6 +4,7 @@ import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -21,6 +22,7 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 open class KtlintExtension
 internal constructor(
     objectFactory: ObjectFactory,
+    projectLayout: ProjectLayout,
     customReportersContainer: NamedDomainObjectContainer<CustomReporter>,
     private val filterTargetApplier: FilterApplier,
     kotlinScriptAdditionalPathApplier: KotlinScriptAdditionalPathApplier
@@ -102,6 +104,18 @@ internal constructor(
     val disabledRules: SetProperty<String> = objectFactory.setProperty {
         set(emptySet())
     }
+
+    /**
+     * Baseline file location.
+     *
+     * Default location is `<projectDir>/ktlintBaseline.xml`.
+     *
+     * @since KtLint `0.41.0`
+     */
+    val baseline: RegularFileProperty = objectFactory.fileProperty()
+        .convention(
+            projectLayout.projectDirectory.file("ktlintBaseline.xml")
+        )
 
     private val kscriptExtension = KScriptExtension(kotlinScriptAdditionalPathApplier)
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jlleitschuh.gradle.ktlint.android.applyKtLintToAndroid
 import org.jlleitschuh.gradle.ktlint.tasks.GenerateReportsTask
+import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
 
 /**
  * Plugin that provides a wrapper over the `ktlint` project.
@@ -23,6 +24,7 @@ open class KtlintPlugin : Plugin<Project> {
 
         holder.addKtLintTasksToKotlinPlugin()
         holder.addKotlinScriptTasks()
+        holder.addGenerateBaselineTask()
         holder.addGitHookTasks()
     }
 
@@ -135,6 +137,13 @@ open class KtlintPlugin : Plugin<Project> {
         addGenerateReportsTaskToProjectMetaFormatTask(generateReportsFormatTask)
     }
 
+    private fun PluginHolder.addGenerateBaselineTask() {
+        createGenerateBaselineTask(
+            this,
+            target.tasks.withType(KtLintCheckTask::class.java)
+        )
+    }
+
     internal class PluginHolder(
         val target: Project
     ) {
@@ -157,6 +166,11 @@ open class KtlintPlugin : Plugin<Project> {
         val ktlintConfiguration = createKtlintConfiguration(target, extension)
         val ktlintRulesetConfiguration = createKtlintRulesetConfiguration(target, ktlintConfiguration)
         val ktlintReporterConfiguration = createKtLintReporterConfiguration(target, extension, ktlintConfiguration)
+        val ktlintBaselineReporterConfiguration = createKtLintBaselineReporterConfiguration(
+            target,
+            extension,
+            ktlintConfiguration
+        )
         val loadReportersTask = createLoadReportersTask(this)
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -161,6 +161,17 @@ private fun <T : BaseKtLintCheckTask> GenerateReportsTask.commonConfiguration(
     ignoreFailures.set(pluginHolder.extension.ignoreFailures)
     verbose.set(pluginHolder.extension.verbose)
     ktLintVersion.set(pluginHolder.extension.version)
+    @Suppress("UnstableApiUsage")
+    baseline.set(
+        pluginHolder.extension.baseline
+            .flatMap {
+                if (it.asFile.exists()) {
+                    pluginHolder.target.objects.fileProperty().apply { set(it.asFile) }
+                } else {
+                    pluginHolder.target.objects.fileProperty()
+                }
+            }
+    )
 }
 
 internal fun createGenerateBaselineTask(

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -1,9 +1,11 @@
 package org.jlleitschuh.gradle.ktlint
 
 import org.gradle.api.file.FileTree
+import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
+import org.jlleitschuh.gradle.ktlint.tasks.GenerateBaselineTask
 import org.jlleitschuh.gradle.ktlint.tasks.GenerateReportsTask
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
@@ -159,4 +161,22 @@ private fun <T : BaseKtLintCheckTask> GenerateReportsTask.commonConfiguration(
     ignoreFailures.set(pluginHolder.extension.ignoreFailures)
     verbose.set(pluginHolder.extension.verbose)
     ktLintVersion.set(pluginHolder.extension.version)
+}
+
+internal fun createGenerateBaselineTask(
+    pluginHolder: KtlintPlugin.PluginHolder,
+    lintTasks: TaskCollection<out BaseKtLintCheckTask>
+): TaskProvider<GenerateBaselineTask> = pluginHolder.target.registerTask(
+    GenerateBaselineTask.NAME
+) {
+    description = GenerateBaselineTask.DESCRIPTION
+    group = HELP_GROUP
+
+    dependsOn(lintTasks)
+
+    ktLintClasspath.setFrom(pluginHolder.ktlintConfiguration)
+    baselineReporterClasspath.setFrom(pluginHolder.ktlintBaselineReporterConfiguration)
+    discoveredErrors.from(lintTasks.map { it.discoveredErrors })
+    ktLintVersion.set(pluginHolder.extension.version)
+    baselineFile.set(pluginHolder.extension.baseline)
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateBaselineTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateBaselineTask.kt
@@ -1,0 +1,82 @@
+package org.jlleitschuh.gradle.ktlint.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.WorkerExecutor
+import org.jlleitschuh.gradle.ktlint.worker.GenerateBaselineWorkAction
+import javax.inject.Inject
+import net.swiftzer.semver.SemVer
+import org.gradle.api.Task
+import org.gradle.api.specs.Spec
+
+/**
+ * Generates KtLint baseline file.
+ *
+ * If baseline file is already exists - it will be overwritten.
+ */
+@CacheableTask
+abstract class GenerateBaselineTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+    private val projectLayout: ProjectLayout
+) : DefaultTask() {
+    @get:Classpath
+    internal abstract val ktLintClasspath: ConfigurableFileCollection
+
+    @get:Classpath
+    internal abstract val baselineReporterClasspath: ConfigurableFileCollection
+
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputFiles
+    internal abstract val discoveredErrors: ConfigurableFileCollection
+
+    @get:Input
+    internal abstract val ktLintVersion: Property<String>
+
+    @get:OutputFile
+    abstract val baselineFile: RegularFileProperty
+
+    final override fun onlyIf(spec: Spec<in Task>) {
+        super.onlyIf(spec)
+    }
+
+    init {
+        onlyIf {
+            val isEnabled = SemVer.parse(ktLintVersion.get()) >= SemVer(0, 41, 0)
+            if (!isEnabled) logger.warn("Generate baseline only works starting from KtLint 0.41.0 version")
+            isEnabled
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    @TaskAction
+    fun generateBaseline() {
+        // Classloader isolation is enough here as we just want to use some classes from KtLint classpath
+        // to get errors and generate files/console reports. No KtLint main object is initialized/used in this case.
+        val queue = workerExecutor.classLoaderIsolation { spec ->
+            spec.classpath.from(ktLintClasspath, baselineReporterClasspath)
+        }
+
+        queue.submit(GenerateBaselineWorkAction::class.java) { param ->
+            param.discoveredErrors.setFrom(discoveredErrors)
+            param.ktLintVersion.set(ktLintVersion)
+            param.baselineFile.set(baselineFile)
+            param.projectDirectory.set(projectLayout.projectDirectory)
+        }
+    }
+
+    companion object {
+        const val NAME = "ktlintGenerateBaseline"
+        const val DESCRIPTION = "Generates KtLint baseline file"
+    }
+}

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateBaselineTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateBaselineTask.kt
@@ -1,10 +1,13 @@
 package org.jlleitschuh.gradle.ktlint.tasks
 
+import net.swiftzer.semver.SemVer
 import org.gradle.api.DefaultTask
+import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
@@ -16,9 +19,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
 import org.jlleitschuh.gradle.ktlint.worker.GenerateBaselineWorkAction
 import javax.inject.Inject
-import net.swiftzer.semver.SemVer
-import org.gradle.api.Task
-import org.gradle.api.specs.Spec
 
 /**
  * Generates KtLint baseline file.

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/GenerateBaselineWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/GenerateBaselineWorkAction.kt
@@ -1,0 +1,74 @@
+package org.jlleitschuh.gradle.ktlint.worker
+
+import com.pinterest.ktlint.core.Reporter
+import com.pinterest.ktlint.core.ReporterProvider
+import net.swiftzer.semver.SemVer
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import java.io.PrintStream
+import java.util.ServiceLoader
+
+@Suppress("UnstableApiUsage")
+internal abstract class GenerateBaselineWorkAction :
+    WorkAction<GenerateBaselineWorkAction.GenerateBaselineParameters> {
+
+    private val logger = Logging.getLogger("ktlint-generate-baseline-worker")
+
+    override fun execute() {
+        val ktLintClassesSerializer = KtLintClassesSerializer.create(
+            SemVer.parse(parameters.ktLintVersion.get())
+        )
+        val errors = parameters
+            .discoveredErrors
+            .files
+            .filter { it.exists() }
+            .map {
+                ktLintClassesSerializer.loadErrors(it)
+            }
+            .flatten()
+
+        val baselineFile = parameters.baselineFile.asFile.get().apply {
+            if (exists()) delete()
+        }
+        val projectDir = parameters.projectDirectory.asFile.get()
+
+        PrintStream(baselineFile.outputStream()).use {
+            val baselineReporter = loadBaselineReporter(it)
+            baselineReporter.beforeAll()
+            errors.forEach { lintErrorResult ->
+                val filePath = lintErrorResult.lintedFile.toRelativeString(projectDir)
+                baselineReporter.before(filePath)
+                lintErrorResult.lintErrors.forEach {
+                    baselineReporter.onLintError(filePath, it.first, it.second)
+                }
+                baselineReporter.after(filePath)
+            }
+            baselineReporter.afterAll()
+        }
+
+        logger.log(
+            LogLevel.WARN,
+            "Baseline was successfully generated into: ${parameters.baselineFile.get().asFile.absolutePath}"
+        )
+    }
+
+    private fun loadBaselineReporter(
+        baselineFile: PrintStream
+    ): Reporter = ServiceLoader
+        .load(ReporterProvider::class.java)
+        .first { it.id == "baseline" }
+        .get(baselineFile, emptyMap())
+
+    internal interface GenerateBaselineParameters : WorkParameters {
+        val discoveredErrors: ConfigurableFileCollection
+        val baselineFile: RegularFileProperty
+        val projectDirectory: DirectoryProperty
+        val ktLintVersion: Property<String>
+    }
+}

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
@@ -1,0 +1,132 @@
+package org.jlleitschuh.gradle.ktlint
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.jlleitschuh.gradle.ktlint.KtlintBasePlugin.Companion.LOWEST_SUPPORTED_GRADLE_VERSION
+import org.jlleitschuh.gradle.ktlint.tasks.GenerateBaselineTask
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Runs [KotlinJsPluginTests] with the current version of Gradle.
+ */
+class GradleCurrentKtlintBaselineSupportTest : KtlintBaselineSupportTest()
+
+/**
+ * Runs [KotlinJsPluginTests] with lowest supported Gradle version.
+ */
+@Suppress("ClassName")
+class GradleLowestSupportedKtlintBaselineSupportTest : KtlintBaselineSupportTest() {
+
+    override fun gradleRunnerFor(
+        vararg arguments: String,
+        projectRoot: File
+    ): GradleRunner =
+        super.gradleRunnerFor(*arguments, projectRoot = projectRoot)
+            .withGradleVersion(LOWEST_SUPPORTED_GRADLE_VERSION)
+}
+
+abstract class KtlintBaselineSupportTest : AbstractPluginTest() {
+    @Test
+    internal fun `Should generate empty baseline file on no style violations`() {
+        with(projectRoot) {
+            defaultProjectSetup()
+            withCleanSources()
+        }
+
+        build(GenerateBaselineTask.NAME).apply {
+            assertThat(task(":${GenerateBaselineTask.NAME}")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            val baselineFile = projectRoot.defaultBaselineFile
+            assertThat(baselineFile).exists()
+            assertThat(baselineFile.readText()).isEqualToNormalizingNewlines(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <baseline version="1.0">
+                </baseline>
+                
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    internal fun `Should generate baseline with found style violations`() {
+        with(projectRoot) {
+            defaultProjectSetup()
+            withFailingSources()
+            withFailingKotlinScript()
+        }
+
+        build(GenerateBaselineTask.NAME).apply {
+            assertThat(task(":${GenerateBaselineTask.NAME}")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            val baselineFile = projectRoot.defaultBaselineFile
+            assertThat(baselineFile).exists()
+            assertThat(baselineFile.readText()).isEqualToNormalizingNewlines(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <baseline version="1.0">
+                	<file name="kotlin-script-fail.kts">
+                		<error line="1" column="15" source="no-trailing-spaces" />
+                	</file>
+                	<file name="src/main/kotlin/fail-source.kt">
+                		<error line="1" column="5" source="no-multi-spaces" />
+                		<error line="1" column="10" source="no-multi-spaces" />
+                		<error line="1" column="15" source="no-multi-spaces" />
+                	</file>
+                </baseline>
+                
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    internal fun `Should overwrite existing baseline file`() {
+        with(projectRoot) {
+            defaultProjectSetup()
+            withFailingSources()
+        }
+
+        build(GenerateBaselineTask.NAME)
+
+        projectRoot.resolve(FAIL_SOURCE_FILE).delete()
+        build(GenerateBaselineTask.NAME).apply {
+            assertThat(task(":${GenerateBaselineTask.NAME}")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            val baselineFile = projectRoot.defaultBaselineFile
+            assertThat(baselineFile).exists()
+            assertThat(baselineFile.readText()).isEqualToNormalizingNewlines(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <baseline version="1.0">
+                </baseline>
+                
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    internal fun `Generate baseline task should work only when ktlint version higher then 0_41_0`() {
+        with(projectRoot) {
+            defaultProjectSetup()
+            withFailingSources()
+
+            buildFile().appendText(
+                """
+                
+                ktlint {
+                    version.set("0.40.0")
+                }
+                """.trimIndent()
+            )
+
+            build(GenerateBaselineTask.NAME).apply {
+                assertThat(task(":${GenerateBaselineTask.NAME}")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
+                assertThat(output).containsSequence("Generate baseline only works starting from KtLint 0.41.0 version")
+            }
+        }
+    }
+
+    private val File.defaultBaselineFile get() = resolve("ktlintBaseline.xml")
+}

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -9,6 +9,7 @@ import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
+import org.jlleitschuh.gradle.ktlint.tasks.GenerateBaselineTask
 
 /**
  * Runs the tests with the current version of Gradle.
@@ -84,11 +85,12 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
                 .filter { it.startsWith("ktlint", ignoreCase = true) }
                 .toList()
 
-            assertThat(ktlintTasks).hasSize(4)
+            assertThat(ktlintTasks).hasSize(5)
             assertThat(ktlintTasks).anyMatch { it.startsWith(CHECK_PARENT_TASK_NAME) }
             assertThat(ktlintTasks).anyMatch { it.startsWith(FORMAT_PARENT_TASK_NAME) }
             assertThat(ktlintTasks).anyMatch { it.startsWith(APPLY_TO_IDEA_TASK_NAME) }
             assertThat(ktlintTasks).anyMatch { it.startsWith(APPLY_TO_IDEA_GLOBALLY_TASK_NAME) }
+            assertThat(ktlintTasks).anyMatch { it.startsWith(GenerateBaselineTask.NAME) }
         }
     }
 
@@ -102,7 +104,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
 
             // Plus for main and test sources format and check tasks
             // Plus two kotlin script tasks
-            assertThat(ktlintTasks).hasSize(10)
+            assertThat(ktlintTasks).hasSize(11)
             assertThat(ktlintTasks).anyMatch { it.startsWith(CHECK_PARENT_TASK_NAME) }
             assertThat(ktlintTasks).anyMatch { it.startsWith(FORMAT_PARENT_TASK_NAME) }
             assertThat(ktlintTasks).anyMatch { it.startsWith(APPLY_TO_IDEA_TASK_NAME) }
@@ -113,6 +115,7 @@ abstract class BaseKtlintPluginTest : AbstractPluginTest() {
                     GenerateReportsTask.generateNameForKotlinScripts(GenerateReportsTask.LintType.FORMAT)
                 )
             }
+            assertThat(ktlintTasks).anyMatch { it.startsWith(GenerateBaselineTask.NAME) }
         }
     }
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -4,12 +4,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.jlleitschuh.gradle.ktlint.KtlintBasePlugin.Companion.LOWEST_SUPPORTED_GRADLE_VERSION
+import org.jlleitschuh.gradle.ktlint.tasks.GenerateBaselineTask
 import org.jlleitschuh.gradle.ktlint.tasks.GenerateReportsTask
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
-import org.jlleitschuh.gradle.ktlint.tasks.GenerateBaselineTask
 
 /**
  * Runs the tests with the current version of Gradle.

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/UnsupportedGradleTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/UnsupportedGradleTest.kt
@@ -3,6 +3,8 @@ package org.jlleitschuh.gradle.ktlint
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import java.io.File
 
 class UnsupportedGradleTest : AbstractPluginTest() {
@@ -14,6 +16,7 @@ class UnsupportedGradleTest : AbstractPluginTest() {
             .withGradleVersion("5.6.4")
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     internal fun `Should raise exception on applying plugin`() {
         projectRoot.defaultProjectSetup()
 


### PR DESCRIPTION
This PR adds initial KtLint baseline support with following limitations:
- Format tasks ignore baseline, see [KtLint 1072 issue](https://github.com/pinterest/ktlint/issues/1072) for more details
- One baseline file is generated per one Gradle project (module). Merging baseline is not possible as KtLint actually uses `Reporter` interface to generate baseline file. Theoretically it will be possible to introduce special generate task in the root project that will trigger all subprojects, collects all errors and then write one baseline file, but let us see how big demand for it will be.

Fixes #414 