### PR TITLE
add changelog action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,21 @@
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled, reopened]
+
+jobs:
+  build:
+    name: Changelog Entry Check
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Grep CHANGES.md for PR number
+        if: contains(github.event.pull_request.labels.*.name, 'skip news') != true
+        run: |
+          grep -Pz "\((\n\s*)?#${{ github.event.pull_request.number }}(\n\s*)?\)" CHANGELOG.md || \
+          (echo "Please add '(#${{ github.event.pull_request.number }})' change line to CHANGELOG.md" && \
+          exit 1)


### PR DESCRIPTION
Verify that the pr is included in the CHANGELOG.md file, if the pr has the "skip news" label then it doesn't apply.