### PR TITLE
Fix changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Grep CHANGES.md for PR number
         if: contains(github.event.pull_request.labels.*.name, 'skip news') != true
         run: |
-          grep -Pz "\((\n\s*)?#${{ github.event.pull_request.number }}(\n\s*)?\)" CHANGELOG.md || \
-          (echo "Please add '(#${{ github.event.pull_request.number }})' change line to CHANGELOG.md" && \
+          grep -Pz "\[(\n\s*)?#${{ github.event.pull_request.number }}(\n\s*)?\]\((\n\s*)?https://github\.com/JLLeitschuh/ktlint-gradle/pull/${{ github.event.pull_request.number }}(\n\s*)?\)" CHANGELOG.md || \
+          (echo "Please add '[#${{ github.event.pull_request.number }}](https://github.com/JLLeitschuh/ktlint-gradle/pull/${{ github.event.pull_request.number }})' change line to CHANGELOG.md" && \
           exit 1)


### PR DESCRIPTION
It was using the wrong format: `(#123)` instead of `[#123](url)`

This will match:
```
[
  #123
](
  https://github.com/JLLeitschuh/ktlint-gradle/pull/123
)
```