### PR TITLE
Resolve pre-commit hook causing conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - ?
 
 ### Fixed
-  - ?
+  - Pre-commit hook causing conflicts ([issue: #443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443)) ([#502](https://github.com/JLLeitschuh/ktlint-gradle/pull/502))
 
 ### Removed
   - ?

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -77,14 +77,22 @@ internal fun generateGitHook(
     echo "Running ktlint over these files:"
     echo "${'$'}CHANGED_FILES"
     
-    git stash push --keep-index
+    diff=.git/unstaged-ktlint-git-hook.diff
+    git diff --color=never > ${'$'}diff
+    if [ -s ${'$'}diff ]; then
+      git apply -R ${'$'}diff
+    fi
     
     ${generateGradleCommand(taskName, gradleRootDirPrefix)}
 
     echo "Completed ktlint run."
     ${postCheck(shouldUpdateCommit)}
     
-    git stash pop
+    if [ -s ${'$'}diff ]; then
+      git apply --ignore-whitespace ${'$'}diff
+    fi
+    rm ${'$'}diff
+    unset diff
     
     echo "Completed ktlint hook."
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -157,8 +157,10 @@ class GitHookTasksTest : AbstractPluginTest() {
         build(":$INSTALL_GIT_HOOK_FORMAT_TASK").run {
             assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
             val hookText = gitDir.preCommitGitHook().readText()
-            assertThat(hookText).contains("git stash push")
-            assertThat(hookText).contains("git stash pop")
+            assertThat(hookText).contains("git diff --color=never > \$diff")
+            assertThat(hookText).contains("git apply -R \$diff")
+            assertThat(hookText).contains("git apply --ignore-whitespace \$diff")
+            assertThat(hookText).contains("rm \$diff")
         }
     }
 


### PR DESCRIPTION
resolves #497

The logic was using `git stash push --keep-index` which keeps the index but also adds it to the stash. I've change the functionality to use a .diff file with the changes `git diff > unstaged.diff` and reapply it with `git apply --ignore-whitespace unstaged.diff`, in my opinion using `-3` would be better but then git applies it to the index, not the working copy.

There isn't a current version in the changes so I bumped it to 10.1.1