### PR TITLE
Prevent creation of empty directories on running format task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
   - Pre-commit hook causing conflicts ([issue: #443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443)) ([#502](https://github.com/JLLeitschuh/ktlint-gradle/pull/502))
+  - Format task creates directories for empty SourceSets ([issue: #423](https://github.com/JLLeitschuh/ktlint-gradle/issues/423))
 
 ### Removed
   - ?

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
@@ -32,7 +32,7 @@ open class KtlintBasePlugin : Plugin<Project> {
         val kotlinScriptAdditionalPathApplier: KotlinScriptAdditionalPathApplier = { additionalFileTree ->
             val configureAction = Action<Task> { task ->
                 with(task as BaseKtLintCheckTask) {
-                    source = source.plus(
+                    source(
                         additionalFileTree.also {
                             it.include("*.kts")
                         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -74,7 +74,7 @@ internal fun createKotlinScriptCheckTask(
     .registerTask(KtLintCheckTask.KOTLIN_SCRIPT_TASK_NAME) {
         description = KtLintCheckTask.buildDescription(".kts")
         configureBaseCheckTask(pluginHolder) {
-            source = projectScriptFiles
+            setSource(projectScriptFiles)
         }
     }
 
@@ -86,7 +86,7 @@ internal fun createKotlinScriptFormatTask(
     .registerTask(KtLintFormatTask.KOTLIN_SCRIPT_TASK_NAME) {
         description = KtLintFormatTask.buildDescription(".kts")
         configureBaseCheckTask(pluginHolder) {
-            source = projectScriptFiles
+            setSource(projectScriptFiles)
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
@@ -1,18 +1,21 @@
 package org.jlleitschuh.gradle.ktlint.tasks
 
+import groovy.lang.Closure
 import net.swiftzer.semver.SemVer
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.FileType
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.model.ReplacedBy
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -21,7 +24,8 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.util.PatternFilterable
+import org.gradle.api.tasks.util.PatternSet
 import org.gradle.work.ChangeType
 import org.gradle.work.Incremental
 import org.gradle.work.InputChanges
@@ -38,10 +42,11 @@ import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
 abstract class BaseKtLintCheckTask @Inject constructor(
-    objectFactory: ObjectFactory,
+    private val objectFactory: ObjectFactory,
     projectLayout: ProjectLayout,
-    private val workerExecutor: WorkerExecutor,
-) : SourceTask() {
+    private val workerExecutor: WorkerExecutor
+) : DefaultTask(),
+    PatternFilterable {
 
     @get:Classpath
     internal abstract val ktLintClasspath: ConfigurableFileCollection
@@ -87,6 +92,9 @@ abstract class BaseKtLintCheckTask @Inject constructor(
         convention("256m")
     }
 
+    private var sourceFiles: ConfigurableFileCollection = objectFactory.fileCollection()
+    private val patternSet: PatternFilterable = PatternSet()
+
     init {
         if (project.hasProperty(FILTER_INCLUDE_PROPERTY_NAME)) {
             applyGitFilter()
@@ -97,17 +105,33 @@ abstract class BaseKtLintCheckTask @Inject constructor(
         }
     }
 
-    @ReplacedBy("stableSources")
-    override fun getSource(): FileTree {
-        return super.getSource()
-    }
-
+    @get:IgnoreEmptyDirectories
     @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
-    internal val stableSources: FileCollection = project.files(
-        { source }
-    )
+    val source: FileCollection = objectFactory
+        .fileCollection()
+        .from({ sourceFiles.asFileTree.matching(patternSet) })
+
+    /**
+     * Sets the source from this task.
+     *
+     * @param source given source objects will be evaluated as per [org.gradle.api.Project.file].
+     */
+    fun setSource(source: Any): BaseKtLintCheckTask {
+        sourceFiles = objectFactory.fileCollection().from(source)
+        return this
+    }
+
+    /**
+     * Adds some source to this task.
+     *
+     * @param sources given source objects will be evaluated as per [org.gradle.api.Project.files].
+     */
+    fun source(vararg sources: Any): BaseKtLintCheckTask {
+        sourceFiles.from(sources)
+        return this
+    }
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
@@ -120,6 +144,41 @@ abstract class BaseKtLintCheckTask @Inject constructor(
             projectLayout.intermediateResultsBuildDir("${name}_errors.bin")
         )
 
+    @Internal
+    override fun getIncludes(): MutableSet<String> = patternSet.includes
+    @Internal
+    override fun getExcludes(): MutableSet<String> = patternSet.excludes
+
+    override fun setIncludes(includes: MutableIterable<String>): BaseKtLintCheckTask =
+        also { patternSet.setIncludes(includes) }
+
+    override fun setExcludes(excludes: MutableIterable<String>): BaseKtLintCheckTask =
+        also { patternSet.setExcludes(excludes) }
+
+    override fun include(vararg includes: String?): BaseKtLintCheckTask =
+        also { patternSet.include(*includes) }
+
+    override fun include(includes: MutableIterable<String>): BaseKtLintCheckTask =
+        also { patternSet.include(includes) }
+
+    override fun include(includeSpec: Spec<FileTreeElement>): BaseKtLintCheckTask =
+        also { patternSet.include(includeSpec) }
+
+    override fun include(includeSpec: Closure<*>): BaseKtLintCheckTask =
+        also { patternSet.include(includeSpec) }
+
+    override fun exclude(vararg excludes: String?): BaseKtLintCheckTask =
+        also { patternSet.exclude(*excludes) }
+
+    override fun exclude(excludes: MutableIterable<String>): BaseKtLintCheckTask =
+        also { patternSet.exclude(excludes) }
+
+    override fun exclude(excludeSpec: Spec<FileTreeElement>): BaseKtLintCheckTask =
+        also { patternSet.exclude(excludeSpec) }
+
+    override fun exclude(excludeSpec: Closure<*>): BaseKtLintCheckTask =
+        also { patternSet.exclude(excludeSpec) }
+
     protected fun runLint(
         inputChanges: InputChanges?,
         formatSources: Boolean,
@@ -128,7 +187,7 @@ abstract class BaseKtLintCheckTask @Inject constructor(
 
         val editorConfigUpdated = wasEditorConfigFilesUpdated(inputChanges)
         val filesToCheck = if (formatSources || editorConfigUpdated || inputChanges == null) {
-            stableSources.files
+            source.files
         } else {
             getChangedSources(inputChanges)
         }
@@ -176,7 +235,7 @@ abstract class BaseKtLintCheckTask @Inject constructor(
     private fun getChangedSources(
         inputChanges: InputChanges
     ): Set<File> = inputChanges
-        .getFileChanges(stableSources)
+        .getFileChanges(source)
         .asSequence()
         .filter {
             it.fileType != FileType.DIRECTORY &&

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintFormatTask.kt
@@ -1,6 +1,6 @@
 package org.jlleitschuh.gradle.ktlint.tasks
 
-import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
@@ -33,9 +33,7 @@ abstract class KtLintFormatTask @Inject constructor(
      */
     @Suppress("unused")
     @OutputFiles
-    fun getOutputSources(): FileTree {
-        return source
-    }
+    fun getOutputSources(): FileCollection = source.filter { !it.exists() }
 
     internal companion object {
         fun buildTaskNameForSourceSet(

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -206,6 +206,18 @@ class KtlintPluginTest : AbstractPluginTest() {
         }
     }
 
+    @DisplayName("Format task should not create directories for empty SourceSets")
+    @CommonTest
+    fun formatNotCreateEmpty(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            withFailingSources()
+
+            build(FORMAT_PARENT_TASK_NAME) {
+                assertThat(projectPath.resolve("src/main/java")).doesNotExist()
+            }
+        }
+    }
+
     @DisplayName("Should apply KtLint version from extension")
     @CommonTest
     fun ktlintVersionFromExtension(gradleVersion: GradleVersion) {


### PR DESCRIPTION
Now base lint task does not extend SourceTask, but DefaultTask + PatternFilterable. This allows for format task to filter empty directories in output, so Gradle will not create empty SourceSet directories.

Fixes #423 