### PR TITLE
Rethink format task approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Update Shadow plugin to `7.0.0` version
   - Update Kotlin to `1.5.21` version
   - Set default KtLint version to `0.42.1`
+  - Rethink format task approach ([issue: #306](https://github.com/JLLeitschuh/ktlint-gradle/issues/306))
 
 ### Fixed
   - Pre-commit hook causing conflicts ([issue: #443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443)) ([#502](https://github.com/JLLeitschuh/ktlint-gradle/pull/502))
-  - `ktlintFormat` create empty directories in `src/` dir ([issue: $423](https://github.com/JLLeitschuh/ktlint-gradle/issues/423))
+  - `ktlintFormat` create empty directories in `src/` dir ([issue: #423](https://github.com/JLLeitschuh/ktlint-gradle/issues/423))
 
 ### Removed
   - ?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
   - Pre-commit hook causing conflicts ([issue: #443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443)) ([#502](https://github.com/JLLeitschuh/ktlint-gradle/pull/502))
+  - `ktlintFormat` create empty directories in `src/` dir ([issue: $423](https://github.com/JLLeitschuh/ktlint-gradle/issues/423))
 
 ### Removed
   - ?

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
@@ -32,7 +32,7 @@ open class KtlintBasePlugin : Plugin<Project> {
         val kotlinScriptAdditionalPathApplier: KotlinScriptAdditionalPathApplier = { additionalFileTree ->
             val configureAction = Action<Task> { task ->
                 with(task as BaseKtLintCheckTask) {
-                    source = source.plus(
+                    source(
                         additionalFileTree.also {
                             it.include("*.kts")
                         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -22,9 +22,14 @@ import java.nio.file.Path
 
 internal inline fun <reified T : Task> Project.registerTask(
     name: String,
+    vararg constructorArguments: Any = emptyArray(),
     noinline configuration: T.() -> Unit
 ): TaskProvider<T> {
-    return this.tasks.register(name, T::class.java, configuration)
+    return tasks
+        .register(name, T::class.java, *constructorArguments)
+        .apply {
+            configure { configuration(it) }
+        }
 }
 
 internal const val EDITOR_CONFIG_FILE_NAME = ".editorconfig"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.util.PatternSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
 import org.jlleitschuh.gradle.ktlint.tasks.GenerateBaselineTask
@@ -31,7 +32,8 @@ internal fun createFormatTask(
 ): TaskProvider<KtLintFormatTask> = pluginHolder
     .target
     .registerTask(
-        KtLintFormatTask.buildTaskNameForSourceSet(sourceSetName)
+        KtLintFormatTask.buildTaskNameForSourceSet(sourceSetName),
+        PatternSet()
     ) {
         mustRunAfter(project.tasks.named(KtLintFormatTask.KOTLIN_SCRIPT_TASK_NAME))
 
@@ -58,7 +60,8 @@ internal fun createCheckTask(
 ): TaskProvider<KtLintCheckTask> = pluginHolder
     .target
     .registerTask(
-        KtLintCheckTask.buildTaskNameForSourceSet(sourceSetName)
+        KtLintCheckTask.buildTaskNameForSourceSet(sourceSetName),
+        PatternSet()
     ) {
         description = KtLintCheckTask.buildDescription(".kt")
         configureBaseCheckTask(pluginHolder) {
@@ -71,7 +74,10 @@ internal fun createKotlinScriptCheckTask(
     projectScriptFiles: FileTree
 ): TaskProvider<KtLintCheckTask> = pluginHolder
     .target
-    .registerTask(KtLintCheckTask.KOTLIN_SCRIPT_TASK_NAME) {
+    .registerTask(
+        KtLintCheckTask.KOTLIN_SCRIPT_TASK_NAME,
+        PatternSet()
+    ) {
         description = KtLintCheckTask.buildDescription(".kts")
         configureBaseCheckTask(pluginHolder) {
             setSource(projectScriptFiles)
@@ -83,7 +89,10 @@ internal fun createKotlinScriptFormatTask(
     projectScriptFiles: FileTree
 ): TaskProvider<KtLintFormatTask> = pluginHolder
     .target
-    .registerTask(KtLintFormatTask.KOTLIN_SCRIPT_TASK_NAME) {
+    .registerTask(
+        KtLintFormatTask.KOTLIN_SCRIPT_TASK_NAME,
+        PatternSet()
+    ) {
         description = KtLintFormatTask.buildDescription(".kts")
         configureBaseCheckTask(pluginHolder) {
             setSource(projectScriptFiles)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -74,7 +74,7 @@ internal fun createKotlinScriptCheckTask(
     .registerTask(KtLintCheckTask.KOTLIN_SCRIPT_TASK_NAME) {
         description = KtLintCheckTask.buildDescription(".kts")
         configureBaseCheckTask(pluginHolder) {
-            source = projectScriptFiles
+            setSource(projectScriptFiles)
         }
     }
 
@@ -86,7 +86,7 @@ internal fun createKotlinScriptFormatTask(
     .registerTask(KtLintFormatTask.KOTLIN_SCRIPT_TASK_NAME) {
         description = KtLintFormatTask.buildDescription(".kts")
         configureBaseCheckTask(pluginHolder) {
-            source = projectScriptFiles
+            setSource(projectScriptFiles)
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintCheckTask.kt
@@ -4,6 +4,7 @@ import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
@@ -14,15 +15,17 @@ abstract class KtLintCheckTask @Inject constructor(
     objectFactory: ObjectFactory,
     projectLayout: ProjectLayout,
     workerExecutor: WorkerExecutor,
+    patternFilterable: PatternFilterable
 ) : BaseKtLintCheckTask(
     objectFactory,
     projectLayout,
     workerExecutor,
+    patternFilterable
 ) {
 
     @TaskAction
     fun lint(inputChanges: InputChanges) {
-        runLint(inputChanges, false)
+        runLint(inputChanges)
     }
 
     internal companion object {

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintFormatTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/KtLintFormatTask.kt
@@ -1,6 +1,6 @@
 package org.jlleitschuh.gradle.ktlint.tasks
 
-import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
@@ -33,9 +33,7 @@ abstract class KtLintFormatTask @Inject constructor(
      */
     @Suppress("unused")
     @OutputFiles
-    fun getOutputSources(): FileTree {
-        return source
-    }
+    fun getOutputSources(): FileCollection = source.filter { !it.exists() }
 
     internal companion object {
         fun buildTaskNameForSourceSet(

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.ParseException
 import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 import net.swiftzer.semver.SemVer
+import org.apache.commons.io.input.MessageDigestCalculatingInputStream
 import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -14,6 +15,15 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
+import org.jlleitschuh.gradle.ktlint.worker.KtLintWorkAction.FormatTaskSnapshot.Companion.contentHash
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
 import java.util.ServiceLoader
 
 @Suppress("UnstableApiUsage")
@@ -39,6 +49,7 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
         resetEditorconfigCache()
 
         val result = mutableListOf<LintErrorResult>()
+        val formattedFiles = mutableMapOf<File, ByteArray>()
 
         parameters.filesToLint.files.forEach {
             val errors = mutableListOf<Pair<LintError, Boolean>>()
@@ -61,6 +72,7 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
                     val updatedFileContent = KtLint.format(ktLintParameters)
 
                     if (updatedFileContent != currentFileContent) {
+                        formattedFiles[it] = contentHash(it)
                         it.writeText(updatedFileContent)
                     }
                 } else {
@@ -89,6 +101,13 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
                 result,
                 parameters.discoveredErrorsFile.asFile.get()
             )
+
+        if (formattedFiles.isNotEmpty()) {
+            val snapshotFile = parameters.formatSnapshot.get().asFile
+                .also { if (!it.exists()) it.createNewFile() }
+            val snapshot = FormatTaskSnapshot(formattedFiles)
+            FormatTaskSnapshot.writeIntoFile(snapshotFile, snapshot)
+        }
     }
 
     private fun resetEditorconfigCache() {
@@ -141,5 +160,38 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
         val discoveredErrorsFile: RegularFileProperty
         val ktLintVersion: Property<String>
         val editorconfigFilesWereChanged: Property<Boolean>
+        val formatSnapshot: RegularFileProperty
+    }
+
+    /**
+     * Represents pre-formatted files snapshot (file + it contents hash).
+     */
+    internal class FormatTaskSnapshot(
+        val formattedSources: Map<File, ByteArray>
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+
+            fun readFromFile(snapshotFile: File) =
+                ObjectInputStream(BufferedInputStream(FileInputStream(snapshotFile)))
+                    .use {
+                        it.readObject() as FormatTaskSnapshot
+                    }
+
+            fun writeIntoFile(
+                snapshotFile: File,
+                formatSnapshot: FormatTaskSnapshot
+            ) = ObjectOutputStream(BufferedOutputStream(FileOutputStream(snapshotFile)))
+                .use {
+                    it.writeObject(formatSnapshot)
+                }
+
+            fun contentHash(file: File): ByteArray {
+                return MessageDigestCalculatingInputStream(BufferedInputStream(FileInputStream(file))).use {
+                    it.readBytes()
+                    it.messageDigest.digest()
+                }
+            }
+        }
     }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -182,8 +182,10 @@ class KtlintPluginTest : AbstractPluginTest() {
 
             build(FORMAT_PARENT_TASK_NAME) {
                 assertThat(task(":$formatTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                assertThat(projectPath.resolve(FAIL_SOURCE_FILE)).exists()
             }
-            assertThat(projectPath.resolve(FAIL_SOURCE_FILE)).exists()
+
+            build(CHECK_PARENT_TASK_NAME)
         }
     }
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -206,6 +206,18 @@ class KtlintPluginTest : AbstractPluginTest() {
         }
     }
 
+    @DisplayName("Format task should not create directories for empty SourceSets")
+    @CommonTest
+    fun formatNotCreateEmpty(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            withFailingSources()
+
+            build(FORMAT_PARENT_TASK_NAME) {
+                assertThat(projectPath.resolve("src/main/java")).doesNotExist()
+            }
+        }
+    }
+
     @DisplayName("Should apply KtLint version from extension")
     @CommonTest
     fun ktlintVersionFromExtension(gradleVersion: GradleVersion) {


### PR DESCRIPTION
`BaseKtlintCheckTask` now extends `DefaultTask` plus implements `PatternFilterable` interface copying approach from `SourceTask`.

To better handle incremental formatting, plus handle the case of restored to pre-formatted state sources, Format task tracks pre-formatted files snapshot: file + content hash. In case sources has the files with same content hash as file in snapshot from previous task execution - format tasks fails up-to-date check and run format again on such files.

Fixes #423
Fixes #306 