### PR TITLE
Register Kotlin script tasks first.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - Pre-commit hook causing conflicts ([issue: #443](https://github.com/JLLeitschuh/ktlint-gradle/issues/443)) ([#502](https://github.com/JLLeitschuh/ktlint-gradle/pull/502))
   - `ktlintFormat` create empty directories in `src/` dir ([issue: #423](https://github.com/JLLeitschuh/ktlint-gradle/issues/423))
   - Add Git hook task breaks configuration cache ([issue: #505](https://github.com/JLLeitschuh/ktlint-gradle/issues/505))
+  - Plugin failed to apply on eager tasks creation ([issue: #495](https://github.com/JLLeitschuh/ktlint-gradle/issues/495))
 
 ### Removed
   - ?

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -22,8 +22,8 @@ open class KtlintPlugin : Plugin<Project> {
         // Apply the idea plugin
         target.plugins.apply(KtlintIdeaPlugin::class.java)
 
-        holder.addKtLintTasksToKotlinPlugin()
         holder.addKotlinScriptTasks()
+        holder.addKtLintTasksToKotlinPlugin()
         holder.addGenerateBaselineTask()
         holder.addGitHookTasks()
     }


### PR DESCRIPTION
So if Kotlin Plugin configures immediately - registered plugin tasks could find expected existing one.

Fixes #495 