### PR TITLE
Do not mark entire root directory as input for git hook task

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -2,12 +2,10 @@ package org.jlleitschuh.gradle.ktlint
 
 import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.intellij.lang.annotations.Language
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
@@ -150,19 +148,13 @@ open class KtlintInstallGitHookTask @Inject constructor(
     @get:Input
     internal val hookName: Property<String> = objectFactory.property(String::class.java)
 
-    @get:InputDirectory
-    internal val projectDir: DirectoryProperty = objectFactory.directoryProperty().apply {
-        set(projectLayout.projectDirectory)
-    }
+    private val projectDir = projectLayout.projectDirectory.asFile
 
-    @get:InputDirectory
-    internal val rootDirectory: DirectoryProperty = objectFactory.directoryProperty().apply {
-        set(project.rootDir)
-    }
+    private val rootDirectory = project.rootDir
 
     @TaskAction
     fun installHook() {
-        val repo = RepositoryBuilder().findGitDir(projectDir.get().asFile).setMustExist(false).build()
+        val repo = RepositoryBuilder().findGitDir(projectDir).setMustExist(false).build()
         if (!repo.objectDatabase.exists()) {
             logger.warn("No git folder was found!")
             return
@@ -181,7 +173,7 @@ open class KtlintInstallGitHookTask @Inject constructor(
             gitHookFile.createNewFile()
             gitHookFile.setExecutable(true)
         }
-        val gradleRootDirPrefix = rootDirectory.get().asFile.relativeTo(repo.workTree).path
+        val gradleRootDirPrefix = rootDirectory.relativeTo(repo.workTree).path
 
         if (gitHookFile.length() == 0L) {
             gitHookFile.writeText(


### PR DESCRIPTION
In PR #526 `projectDir` and `rootDirectory` were marked with `@InputDirectory` annotation to fix problems with Gradle configuration cache. But those annotations actually mean that `addKtlintCheckGitPreCommitHook` task is using entire root directory content as its input. This does not make much sense. Not only that but in Gradle 7.x it causes annoying output when `addKtlintCheckGitPreCommitHook` task is executed together with other tasks. In case of my project I have configured `build` task to depend on `addKtlintCheckGitPreCommitHook` (`build.dependsOn addKtlintCheckGitPreCommitHook`) and now when I do `./gradlew build` in Gradle 7.x (I'm testing on 7.2 to be exact) I get a lot of output like below:
```
> Task :compileKotlin
Execution optimizations have been disabled for task ':compileKotlin' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '<PROJECT_DIR>/build/classes/kotlin/main'. Reason: Task ':addKtlintCheckGitPreCommitHook' uses this output of task ':compileKotlin' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '<PROJECT_DIR>/build/kotlin/compileKotlin'. Reason: Task ':addKtlintCheckGitPreCommitHook' uses this output of task ':compileKotlin' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
`addKtlintCheckGitPreCommitHook` does not really depend on content of any of those directories so using `@InputDirectory` annotation is a mistake. Instead `@Input` annotation can be used with a `String` property (that's what JavaDoc of `@InputDirectory` annotation suggests for situations when directory content does not matter).
But I went with a simpler solution making `projectDir` and `rootDir` regular private Kotlin property that Gradle does not see and track. I think intention of PR #526 wasn't to make those values configurable as task inputs so there's no need to mark them with `@Input` annotation. There is also `@Internal` annotation but I do not see any benefit of using it here over private property.
I tested code with my project and no `Execution optimizations have been disabled` warnings were printed anymore.

If you like/accept my Pull Request please add `hacktoberfest-accepted` label so it can be counted as my opensource contribution in Hacktoberfest contest. 