### PR TITLE
Use Gradle command exit code as hook exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
   - Deleted file causes file not found exception ([issue: #539](https://github.com/JLLeitschuh/ktlint-gradle/issues/539), [#548](https://github.com/JLLeitschuh/ktlint-gradle/pull/548))
-
+  - Use Gradle command exit code as hook exit code to ensure un-staged changes are always re-applied to the working directory [#551](https://github.com/JLLeitschuh/ktlint-gradle/pull/551)
 ### Removed
   - ?
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -19,7 +19,6 @@ internal const val FILTER_INCLUDE_PROPERTY_NAME = "internalKtlintGitFilter"
 internal val shShebang =
     """
     #!/bin/sh
-    set -e
 
     """.trimIndent()
 
@@ -61,6 +60,7 @@ private fun postCheck(
 }
 
 internal const val NF = "\$NF"
+internal const val gradleCommandExitCode = "\$gradleCommandExitCode"
 
 @Language("Sh")
 internal fun generateGitHook(
@@ -79,25 +79,27 @@ internal fun generateGitHook(
 
     echo "Running ktlint over these files:"
     echo "${'$'}CHANGED_FILES"
-    
+
     diff=.git/unstaged-ktlint-git-hook.diff
     git diff --color=never > ${'$'}diff
     if [ -s ${'$'}diff ]; then
       git apply -R ${'$'}diff
     fi
-    
+
     ${generateGradleCommand(taskName, gradleRootDirPrefix)}
+    $gradleCommandExitCode=$?
 
     echo "Completed ktlint run."
     ${postCheck(shouldUpdateCommit)}
-    
+
     if [ -s ${'$'}diff ]; then
       git apply --ignore-whitespace ${'$'}diff
     fi
     rm ${'$'}diff
     unset diff
-    
+
     echo "Completed ktlint hook."
+    exit $gradleCommandExitCode
 
     """.trimIndent()
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -154,6 +154,10 @@ class GitHookTasksTest : AbstractPluginTest() {
     @DisplayName("Collects check run exit code and uses it to indicate check success")
     @CommonTest
     fun checkUsesGradleExitCode(gradleVersion: GradleVersion) {
+        // This test ensures that we use the exit code of the check gradle command as the exit code
+        // of the hook script to indicate success/failure instead of using set -e, because
+        // that will prevent the saved un-staged changes from being re-applied to the working dir.
+        // See [#551](https://github.com/JLLeitschuh/ktlint-gradle/pull/551)
         project(gradleVersion) {
             val gitDir = projectPath.initGit()
 
@@ -169,6 +173,10 @@ class GitHookTasksTest : AbstractPluginTest() {
     @DisplayName("Collects format run exit code and uses it to indicate format success")
     @CommonTest
     fun formatUsesGradleExitCode(gradleVersion: GradleVersion) {
+        // This test ensures that we use the exit code of the format gradle command as the exit code
+        // of the hook script to indicate success/failure instead of using set -e, because
+        // that will prevent the saved un-staged changes from being re-applied to the working dir.
+        // See [#551](https://github.com/JLLeitschuh/ktlint-gradle/pull/551)
         project(gradleVersion) {
             val gitDir = projectPath.initGit()
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -22,7 +22,7 @@ class GitHookTasksTest : AbstractPluginTest() {
             projectPath.initGit()
             settingsGradle.appendText(
                 """
-                    
+
                 include ":some-module"
                 """.trimIndent()
             )
@@ -97,11 +97,11 @@ class GitHookTasksTest : AbstractPluginTest() {
             gitDir.preCommitGitHook().writeText(
                 """
                 $shShebang
-    
+
                 echo "test1"
                 $startHookSection
-    
-    
+
+
                 $endHookSection
                 echo "test2"
                 """.trimIndent()
@@ -114,7 +114,7 @@ class GitHookTasksTest : AbstractPluginTest() {
             assertThat(hookContent).startsWith(
                 """
                 $shShebang
-    
+
                 echo "test1"
                 """.trimIndent()
             )
@@ -147,6 +147,36 @@ class GitHookTasksTest : AbstractPluginTest() {
             build(":$INSTALL_GIT_HOOK_CHECK_TASK") {
                 assertThat(task(":$INSTALL_GIT_HOOK_CHECK_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                 assertThat(gitDir.preCommitGitHook().readText()).doesNotContain("git add")
+            }
+        }
+    }
+
+    @DisplayName("Collects check run exit code and uses it to indicate check success")
+    @CommonTest
+    fun checkUsesGradleExitCode(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            val gitDir = projectPath.initGit()
+
+            build(":$INSTALL_GIT_HOOK_CHECK_TASK") {
+                assertThat(task(":$INSTALL_GIT_HOOK_CHECK_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                assertThat(gitDir.preCommitGitHook().readText()).doesNotContain("set -e")
+                assertThat(gitDir.preCommitGitHook().readText()).contains("gradleCommandExitCode=\$?")
+                assertThat(gitDir.preCommitGitHook().readText()).contains("exit \$gradleCommandExitCode")
+            }
+        }
+    }
+
+    @DisplayName("Collects format run exit code and uses it to indicate format success")
+    @CommonTest
+    fun formatUsesGradleExitCode(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            val gitDir = projectPath.initGit()
+
+            build(":$INSTALL_GIT_HOOK_FORMAT_TASK") {
+                assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                assertThat(gitDir.preCommitGitHook().readText()).doesNotContain("set -e")
+                assertThat(gitDir.preCommitGitHook().readText()).contains("gradleCommandExitCode=\$?")
+                assertThat(gitDir.preCommitGitHook().readText()).contains("exit \$gradleCommandExitCode")
             }
         }
     }


### PR DESCRIPTION
The hook was using set -e, which meant that if the gradle command failed, then the saved unstaged changes in the diff file were never re-applied.

This change removes the use of set -e and Instead uses the exit code of the gradle task to indicate the success or failure of the hook after the unstaged changes are re-applied. This will ensure unstaged changes are always re-applied regardless of whether or not the check or format has failed or passed