### PR TITLE
Fix error in pre-commit hook bash syntax and improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - ?
 
 ### Fixed
+  - Pre-commit hook syntax causing `command not found` [issue: #562](https://github.com/JLLeitschuh/ktlint-gradle/issues/562), [#568](https://github.com/JLLeitschuh/ktlint-gradle/pull/568)
   - Fix install hook action when git `hooks` folder doesn't exist [issue: #557](https://github.com/JLLeitschuh/ktlint-gradle/issues/557), [#563](https://github.com/JLLeitschuh/ktlint-gradle/pull/563)
 
 ### Removed

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -54,13 +54,12 @@ private fun postCheck(
             git add ${'$'}file
         fi
     done
-    """.trimIndent()
+    """
 } else {
     ""
 }
 
 internal const val NF = "\$NF"
-internal const val gradleCommandExitCode = "\$gradleCommandExitCode"
 
 @Language("Sh")
 internal fun generateGitHook(
@@ -87,7 +86,7 @@ internal fun generateGitHook(
     fi
 
     ${generateGradleCommand(taskName, gradleRootDirPrefix)}
-    $gradleCommandExitCode=$?
+    gradle_command_exit_code=$?
 
     echo "Completed ktlint run."
     ${postCheck(shouldUpdateCommit)}
@@ -99,7 +98,7 @@ internal fun generateGitHook(
     unset diff
 
     echo "Completed ktlint hook."
-    exit $gradleCommandExitCode
+    exit ${'$'}gradle_command_exit_code
 
     """.trimIndent()
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/GitHookTasksTest.kt
@@ -178,9 +178,10 @@ class GitHookTasksTest : AbstractPluginTest() {
 
             build(":$INSTALL_GIT_HOOK_CHECK_TASK") {
                 assertThat(task(":$INSTALL_GIT_HOOK_CHECK_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                assertThat(gitDir.preCommitGitHook().readText()).doesNotContain("set -e")
-                assertThat(gitDir.preCommitGitHook().readText()).contains("gradleCommandExitCode=\$?")
-                assertThat(gitDir.preCommitGitHook().readText()).contains("exit \$gradleCommandExitCode")
+                val hookTextLines = gitDir.preCommitGitHook().readLines()
+                assertThat(hookTextLines).doesNotContain("set -e")
+                assertThat(hookTextLines).contains("gradle_command_exit_code=\$?")
+                assertThat(hookTextLines).contains("exit \$gradle_command_exit_code")
             }
         }
     }
@@ -197,9 +198,10 @@ class GitHookTasksTest : AbstractPluginTest() {
 
             build(":$INSTALL_GIT_HOOK_FORMAT_TASK") {
                 assertThat(task(":$INSTALL_GIT_HOOK_FORMAT_TASK")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                assertThat(gitDir.preCommitGitHook().readText()).doesNotContain("set -e")
-                assertThat(gitDir.preCommitGitHook().readText()).contains("gradleCommandExitCode=\$?")
-                assertThat(gitDir.preCommitGitHook().readText()).contains("exit \$gradleCommandExitCode")
+                val hookTextLines = gitDir.preCommitGitHook().readLines()
+                assertThat(hookTextLines).doesNotContain("set -e")
+                assertThat(hookTextLines).contains("gradle_command_exit_code=\$?")
+                assertThat(hookTextLines).contains("exit \$gradle_command_exit_code")
             }
         }
     }


### PR DESCRIPTION
Fixes #562 

Instead of creating a new local variable `gradle_command_exit_code` the script instead tried to set to value to the variable `$gradle_command_exit_code`.
I fixes the bad syntax and improved the tests. The tests should have actually detected this, but because the pre-commit file was read as a String (`readText()`) the contains assert check returned true because `$gradle_command_exit_code` contains `gradle_command_exit_code`. I switched the logic to `readLines()` to check if the file actually contains the exact line. By that I fixed a indentation issue caused by the nested `trimIndent()` call.