### PR TITLE
Configure configurations as resolvable non-consumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
   - Fix install hook action when git `hooks` folder doesn't exist [issue: #557](https://github.com/JLLeitschuh/ktlint-gradle/issues/557), [#563](https://github.com/JLLeitschuh/ktlint-gradle/pull/563)
+  - Fix some resolution issues when a project using the plugin in some specific setups is depended upon by another project [issue: #523](https://github.com/JLLeitschuh/ktlint-gradle/issues/523), [#571](https://github.com/JLLeitschuh/ktlint-gradle/pull/571)
 
 ### Removed
   - ?

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
@@ -27,6 +27,10 @@ internal fun createKtlintConfiguration(target: Project, extension: KtlintExtensi
 
         description = KTLINT_CONFIGURATION_DESCRIPTION
 
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isVisible = false
+
         // Starting from KtLint 0.41.0 version published artifact has two variants: "external" and "shadowed"
         attributes {
             it.attribute(Bundling.BUNDLING_ATTRIBUTE, target.objects.named(Bundling::class.java, Bundling.EXTERNAL))
@@ -51,6 +55,11 @@ internal fun createKtlintRulesetConfiguration(
 ): Configuration = target
     .configurations.maybeCreate(KTLINT_RULESET_CONFIGURATION_NAME).apply {
         description = KTLINT_RULESET_CONFIGURATION_DESCRIPTION
+
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isVisible = false
+
         ensureConsistencyWith(target, ktLintConfiguration)
     }
 
@@ -63,6 +72,11 @@ internal fun createKtLintReporterConfiguration(
     .maybeCreate(KTLINT_REPORTER_CONFIGURATION_NAME)
     .apply {
         description = KTLINT_REPORTER_CONFIGURATION_DESCRIPTION
+
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isVisible = false
+
         ensureConsistencyWith(target, ktLintConfiguration)
 
         withDependencies {
@@ -92,6 +106,11 @@ internal fun createKtLintBaselineReporterConfiguration(
     .maybeCreate(KTLINT_BASELINE_REPORTER_CONFIGURATION_NAME)
     .apply {
         description = KTLINT_BASELINE_REPORTER_CONFIGURATION_DESCRIPTION
+
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isVisible = false
+
         ensureConsistencyWith(target, ktLintConfiguration)
 
         withDependencies {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -508,6 +508,51 @@ class KtlintPluginTest : AbstractPluginTest() {
         }
     }
 
+    @DisplayName("Should not leak KtLint as a variant into consuming projects")
+    @CommonTest
+    fun noLeakIntoConsumingProjects(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            val producerDir = projectPath.resolve("producer").also { it.mkdirs() }
+            val consumerDir = projectPath.resolve("consumer").also { it.mkdirs() }
+            settingsGradle.appendText(
+                """
+
+                include ":producer"
+                include ":consumer"
+                """.trimIndent()
+            )
+
+            //language=Groovy
+            producerDir.buildFile().writeText(
+                """
+                plugins {
+                    id "org.jlleitschuh.gradle.ktlint"
+                }
+                configurations.create('default')
+                artifacts {
+                    add('default', buildFile)
+                }
+                """.trimIndent()
+            )
+
+            //language=Groovy
+            consumerDir.buildFile().writeText(
+                """
+                plugins {
+                    id 'java'
+                }
+                dependencies {
+                    implementation project(':producer')
+                }
+                """.trimIndent()
+            )
+
+            build(":consumer:dependencies") {
+                assertThat(output).doesNotContain("com.pinterest:ktlint")
+            }
+        }
+    }
+
     @DisplayName("Should print paths to the generated reports on code style violations")
     @CommonTest
     fun printReportsPaths(gradleVersion: GradleVersion) {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -508,6 +508,9 @@ class KtlintPluginTest : AbstractPluginTest() {
         }
     }
 
+    /**
+     * See: https://github.com/JLLeitschuh/ktlint-gradle/issues/523#issuecomment-1022522032
+     */
     @DisplayName("Should not leak KtLint as a variant into consuming projects")
     @CommonTest
     fun noLeakIntoConsumingProjects(gradleVersion: GradleVersion) {


### PR DESCRIPTION
Keeping the default of being consumable exposes them to
variant-aware resolution when the project is depended
upon from another project.

Also configure the configurations as non-visible for
similar reasons: those are specific to this project's
build and there's no reason to consume them from
another project.

Fix #523