### PR TITLE
Add relative option similar to CLI's --relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+  - `relative` option to generate reports with paths relative to the root project ([#573](https://github.com/JLLeitschuh/ktlint-gradle/pull/573))
+
 ### Fixed
   - Fix install hook action when git `hooks` folder doesn't exist [issue: #557](https://github.com/JLLeitschuh/ktlint-gradle/issues/557), [#563](https://github.com/JLLeitschuh/ktlint-gradle/pull/563)
   - Fix pre-commit hook command not found error [issue: #562](https://github.com/JLLeitschuh/ktlint-gradle/issues/562), [#564](https://github.com/JLLeitschuh/ktlint-gradle/pull/564)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -38,6 +38,11 @@ internal constructor(
     val version: Property<String> = objectFactory.property { set("0.42.1") }
 
     /**
+     * Enable relative paths in reports
+     */
+    val relative: Property<Boolean> = objectFactory.property { set(false) }
+
+    /**
      * Enable verbose mode.
      */
     val verbose: Property<Boolean> = objectFactory.property { set(false) }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -184,6 +184,7 @@ private fun <T : BaseKtLintCheckTask> GenerateReportsTask.commonConfiguration(
     ignoreFailures.set(pluginHolder.extension.ignoreFailures)
     verbose.set(pluginHolder.extension.verbose)
     ktLintVersion.set(pluginHolder.extension.version)
+    relative.set(pluginHolder.extension.relative)
     @Suppress("UnstableApiUsage")
     baseline.set(
         pluginHolder.extension.baseline

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateReportsTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateReportsTask.kt
@@ -82,6 +82,9 @@ abstract class GenerateReportsTask @Inject constructor(
     @get:Input
     internal abstract val ktLintVersion: Property<String>
 
+    @get:Input
+    internal abstract val relative: Property<Boolean>
+
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
     @get:Optional
@@ -138,6 +141,9 @@ abstract class GenerateReportsTask @Inject constructor(
                 param.ktLintVersion.set(ktLintVersion)
                 param.baseline.set(baseline)
                 param.projectDirectory.set(projectLayout.projectDirectory)
+                if (relative.get()) {
+                    param.filePathsRelativeTo.set(project.rootDir)
+                }
             }
         }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/GenerateReportsWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/GenerateReportsWorkAction.kt
@@ -45,7 +45,7 @@ internal abstract class GenerateReportsWorkAction : WorkAction<GenerateReportsWo
 
             reporter.beforeAll()
             discoveredErrors.forEach { lintErrorResult ->
-                val filePath = lintErrorResult.lintedFile.absolutePath
+                val filePath = filePathForReport(lintErrorResult.lintedFile)
                 val baselineLintErrors = baselineRules?.get(
                     lintErrorResult.lintedFile.toRelativeString(projectDir).replace(File.separatorChar, '/')
                 )
@@ -61,6 +61,15 @@ internal abstract class GenerateReportsWorkAction : WorkAction<GenerateReportsWo
         }
     }
 
+    private fun filePathForReport(file: File): String {
+        val rootDir = parameters.filePathsRelativeTo.orNull
+        if (rootDir != null) {
+            return file.toRelativeString(rootDir)
+        }
+
+        return file.absolutePath
+    }
+
     internal interface GenerateReportsParameters : WorkParameters {
         val discoveredErrorsFile: RegularFileProperty
         val loadedReporterProviders: RegularFileProperty
@@ -70,5 +79,6 @@ internal abstract class GenerateReportsWorkAction : WorkAction<GenerateReportsWo
         val ktLintVersion: Property<String>
         val baseline: RegularFileProperty
         val projectDirectory: DirectoryProperty
+        val filePathsRelativeTo: Property<File>
     }
 }


### PR DESCRIPTION
We use this gradle plugin in GitLab-CI and currently it always produces absolute paths which leads to broken links in the code quality report.

This PR adds the option `relative` analog to ktlint's CLI's `--relative` option, which does the same thing: Instead of outputting absolute paths in the report, the reports are made relative to the root project (ktlint make it relative to the workdir).

Currently this is only applied to the actual report file output, not the console output to still have clickable file paths in IntelliJ.