### PR TITLE
bump kotlin to 1.5.31, bump ktlint to 0.43.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+-   **Breaking**: minimal supported Gradle version is `6.8`
+-   Update Kotlin to `1.5.31` version
+-   Set default KtLint version to `0.43.2`
+
 ## [10.3.0] - 2022-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
--   **Breaking**: minimal supported Gradle version is `6.8`
--   Update Kotlin to `1.5.31` version
--   Set default KtLint version to `0.43.2`
+-   **Breaking**: minimal supported Gradle version is `6.8` ([#597](https://github.com/JLLeitschuh/ktlint-gradle/pull/597))
+-   Update Kotlin to `1.5.31` version ([#597](https://github.com/JLLeitschuh/ktlint-gradle/pull/597))
+-   Set default KtLint version to `0.43.2` ([#597](https://github.com/JLLeitschuh/ktlint-gradle/pull/597))
 
 ## [10.3.0] - 2022-05-03
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ open a [new issue](https://github.com/JLLeitschuh/ktlint-gradle/issues/new).
 This plugin was written using the new API available for the Gradle script Kotlin builds.
 This API is available in new versions of Gradle.
 
-Minimal supported [Gradle](https://www.gradle.org) version: `6.0`
+Minimal supported [Gradle](https://www.gradle.org) version: `6.8`
 
 Minimal supported [ktlint](https://github.com/pinterest/ktlint) version: `0.34.0`
-(additionally excluding `0.37.0` on Windows OS and `0.38.0` on all OS types)
+(additionally excluding `0.37.0` on Windows OS and `0.38.0`, `0.43.0`, `0.43.1` on all OS types)
 
 ### Ktlint plugin
 
@@ -566,7 +566,7 @@ To run tests in [IDEA IDE](https://www.jetbrains.com/idea/),
 firstly you need to run following gradle task (or after any dependency change):
 
 ```bash
-$ ./plugin/gradlew pluginUnderTestMetadata
+$ ./plugin/gradlew -p ./plugin pluginUnderTestMetadata
 ```
 
 Optionally you can add this step test run configuration.

--- a/plugin/gradle/libs.versions.toml
+++ b/plugin/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.5.21"
-ktlint = "0.42.1"
+kotlin = "1.5.31"
+ktlint = "0.43.2"
 androidPlugin = "4.1.0"
 semver = "1.1.1"
 jgit = "5.6.0.201912101111-r"

--- a/plugin/settings.gradle.kts
+++ b/plugin/settings.gradle.kts
@@ -2,7 +2,7 @@ pluginManagement {
     val latestRelease = file("VERSION_LATEST_RELEASE.txt").readText().trim()
     plugins {
         id("org.jlleitschuh.gradle.ktlint") version latestRelease
-        id("org.jetbrains.kotlin.jvm") version "1.5.21"
+        id("org.jetbrains.kotlin.jvm") version "1.5.31"
         id("com.gradle.plugin-publish") version "0.15.0"
         `java-gradle-plugin`
         `maven-publish`

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBasePlugin.kt
@@ -63,6 +63,6 @@ open class KtlintBasePlugin : Plugin<Project> {
     }
 
     companion object {
-        const val LOWEST_SUPPORTED_GRADLE_VERSION = "6.0"
+        const val LOWEST_SUPPORTED_GRADLE_VERSION = "6.8"
     }
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -35,7 +35,7 @@ internal constructor(
     /**
      * The version of KtLint to use.
      */
-    val version: Property<String> = objectFactory.property { set("0.42.1") }
+    val version: Property<String> = objectFactory.property { set("0.43.2") }
 
     /**
      * Enable relative paths in reports

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ConfigurationCacheTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ConfigurationCacheTest.kt
@@ -10,21 +10,10 @@ import org.jlleitschuh.gradle.ktlint.testdsl.build
 import org.jlleitschuh.gradle.ktlint.testdsl.project
 import org.junit.jupiter.api.DisplayName
 
-@GradleTestVersions(minVersion = "6.6.1")
+@GradleTestVersions
 class ConfigurationCacheTest : AbstractPluginTest() {
     private val configurationCacheFlag = "--configuration-cache"
     private val configurationCacheWarnFlag = "--configuration-cache-problems=warn"
-
-    /**
-     * 2 warnings are still reported by the Kotlin plugin. We can't fix them.
-     * But make sure we aren't creating more issues.
-     * ```
-     * 2 problems were found storing the configuration cache, 1 of which seems unique.
-     * plugin 'org.jetbrains.kotlin.jvm': registration of listener on 'Gradle.addBuildListener' is unsupported
-     * See https://docs.gradle.org/6.6-milestone-3/userguide/configuration_cache.html#config_cache:requirements:build_listeners
-     * ```
-     */
-    private val maxProblemsFlag = "-Dorg.gradle.unsafe.configuration-cache.max-problems=2"
 
     @DisplayName("Should support configuration cache without errors on running linting")
     @CommonTest
@@ -34,14 +23,13 @@ class ConfigurationCacheTest : AbstractPluginTest() {
                 "src/main/kotlin/clean-source.kt",
                 """
                 val foo = "bar"
-                
+
                 """.trimIndent()
             )
 
             build(
                 configurationCacheFlag,
                 configurationCacheWarnFlag,
-                maxProblemsFlag,
                 CHECK_PARENT_TASK_NAME
             ) {
                 assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -50,7 +38,6 @@ class ConfigurationCacheTest : AbstractPluginTest() {
             build(
                 configurationCacheFlag,
                 configurationCacheWarnFlag,
-                maxProblemsFlag,
                 CHECK_PARENT_TASK_NAME
             ) {
                 assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
@@ -74,7 +61,6 @@ class ConfigurationCacheTest : AbstractPluginTest() {
             build(
                 configurationCacheFlag,
                 configurationCacheWarnFlag,
-                maxProblemsFlag,
                 FORMAT_PARENT_TASK_NAME
             ) {
                 assertThat(task(":$formatTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -84,7 +70,6 @@ class ConfigurationCacheTest : AbstractPluginTest() {
             build(
                 configurationCacheFlag,
                 configurationCacheWarnFlag,
-                maxProblemsFlag,
                 FORMAT_PARENT_TASK_NAME
             ) {
                 assertThat(task(":$formatTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -32,7 +32,7 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             //language=Groovy
             buildGradle.appendText(
                 """
-                    
+
                 ktlint.version = "$ktLintVersion"
                 """.trimIndent()
             )
@@ -56,9 +56,9 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             //language=Groovy
             buildGradle.appendText(
                 """
-                
+
                 ktlint.version = "$ktLintVersion"
-                
+
                 """.trimIndent()
             )
 
@@ -82,7 +82,7 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             buildGradle.appendText(
                 """
                 ktlint.version = "$ktLintVersion"
-                
+
                 """.trimIndent()
             )
 
@@ -108,7 +108,10 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             "0.40.0",
             "0.41.0",
             "0.42.0",
-            "0.42.1"
+            "0.42.1",
+            // "0.43.0" does not work on JDK1.8
+            // "0.43.1" asked not to use it
+            "0.43.2",
         ).also {
             // "0.37.0" is failing on Windows machines that is fixed in the next version
             if (!OS.WINDOWS.isCurrentOs) it.add("0.37.0")

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -588,7 +588,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             )
 
             build(":dependencies", "--configuration", KTLINT_RULESET_CONFIGURATION_NAME) {
-                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.42.1")
+                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.43.2")
             }
         }
     }
@@ -610,7 +610,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             )
 
             build(":dependencies", "--configuration", KTLINT_REPORTER_CONFIGURATION_NAME) {
-                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.42.1")
+                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.43.2")
             }
         }
     }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/testAnnotations.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/testAnnotations.kt
@@ -15,7 +15,7 @@ object TestVersions {
     const val maxSupportedGradleVersion = "7.1.1"
     val pluginVersion = File("VERSION_CURRENT.txt").readText().trim()
     const val minSupportedKotlinPluginVersion = "1.4.32"
-    const val maxSupportedKotlinPluginVersion = "1.5.21"
+    const val maxSupportedKotlinPluginVersion = "1.5.31"
 }
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,8 +4,8 @@ pluginManagement {
     includeBuild("./plugin")
 
     plugins {
-        id("org.jetbrains.kotlin.jvm") version "1.5.21"
-        id("org.jetbrains.kotlin.js") version "1.5.21"
+        id("org.jetbrains.kotlin.jvm") version "1.5.31"
+        id("org.jetbrains.kotlin.js") version "1.5.31"
     }
 
     repositories {


### PR DESCRIPTION
Based on [this](https://github.com/JLLeitschuh/ktlint-gradle/pull/595), I decided to create a PR that would bump ktlint to newer version. Instead of trying to update to the newest version in one PR, I find it more convenient to split the update into more smaller parts.

Ktlint 0.43.2 requires at least kotlin 1.4 API. That's why I needed to change the minimum required gradle version to 6.8.

In next PR I would try to update gradle from 7.1.1 -> 7.2 :)

