### PR TITLE
Improve execution in other then main worktree

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -79,7 +79,9 @@ internal fun generateGitHook(
     echo "Running ktlint over these files:"
     echo "${'$'}CHANGED_FILES"
 
-    diff=.git/unstaged-ktlint-git-hook.diff
+    GITDIR=$(git rev-parse --git-dir)
+    diff=$GITDIR/unstaged-ktlint-git-hook.diff
+
     git diff --color=never > ${'$'}diff
     if [ -s ${'$'}diff ]; then
       git apply -R ${'$'}diff


### PR DESCRIPTION
The hook does not run when in other worktrees since .git is not located there.