### PR TITLE
Update wrong task name in "Tasks Added" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Then for each `SourceSet` plugin adds following tasks:
 - `ktlint[source set name]SourceSetCheck` - generates reports and prints issues into Gradle console based on lint check found errors.
   This task execution depends on `loadKtlintReporters` and `runKtlintCheckOver[source set name]SourceSet` tasks execution outputs
 - `runKtlintFormatOver[source set name]SourceSet` - tries to format according to the code style every Kotlin file in given `SourceSet`
-- `ktlint[source set name]SourceSetFormat` - generates reports and prints issues into Gradle console based on found non-formattable errors.
+- `ktlint[source set name]SourceSetFormat` - reformats files, generates reports and prints issues into Gradle console based on found non-formattable errors.
   This task execution depends on `loadKtlintReporters` and `runKtlintFormatOver[source set name]SourceSet` tasks execution outputs
 
 ### Additional helper tasks

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Then for each `SourceSet` plugin adds following tasks:
 - `ktlint[source set name]SourceSetCheck` - generates reports and prints issues into Gradle console based on lint check found errors.
   This task execution depends on `loadKtlintReporters` and `runKtlintCheckOver[source set name]SourceSet` tasks execution outputs
 - `runKtlintFormatOver[source set name]SourceSet` - tries to format according to the code style every Kotlin file in given `SourceSet`
-- `ktlint[source set name]SourceSetCheck` - generates reports and prints issues into Gradle console based on found non-formattable errors.
+- `ktlint[source set name]SourceSetFormat` - generates reports and prints issues into Gradle console based on found non-formattable errors.
   This task execution depends on `loadKtlintReporters` and `runKtlintFormatOver[source set name]SourceSet` tasks execution outputs
 
 ### Additional helper tasks


### PR DESCRIPTION
In the README, **Tasks Added** list includes the task `ktlint[source set name]SourceSetCheck` twice.
The second listing of the task should actually be named `ktlint[source set name]SourceSetFormat`.