### PR TITLE
warn when additionalEditorconfigFile is used in 0.47+ fixes #633

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+
+-   warn when additionalEditorconfigFile is used in 0.47+ [#637](https://github.com/JLLeitschuh/ktlint-gradle/pull/637)
 -   add ktlint version 0.48.2 to testing [#632](https://github.com/JLLeitschuh/ktlint-gradle/pull/632)
 -   update latest gradle version for testing to 7.6 [#632](https://github.com/JLLeitschuh/ktlint-gradle/pull/632)
 -   improve release process to update VERSION_LATEST_RELEASE automatically [#631](https://github.com/JLLeitschuh/ktlint-gradle/pull/631)

--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ ktlint {
     outputColorName = "RED"
     ignoreFailures = true
     enableExperimentalRules = true
-    additionalEditorconfigFile = file("/some/additional/.editorconfig")
-    disabledRules = ["final-newline"]
+    additionalEditorconfigFile = file("/some/additional/.editorconfig")  // not supported with ktlint 0.47+
+    disabledRules = ["final-newline"] // not supported with ktlint 0.48+
     baseline = file("my-project-ktlint-baseline.xml")
     reporters {
         reporter "plain"
@@ -336,8 +336,8 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
     outputColorName.set("RED")
     ignoreFailures.set(true)
     enableExperimentalRules.set(true)
-    additionalEditorconfigFile.set(file("/some/additional/.editorconfig"))
-    disabledRules.set(setOf("final-newline"))
+    additionalEditorconfigFile.set(file("/some/additional/.editorconfig")) // not supported with ktlint 0.47+
+    disabledRules.set(setOf("final-newline")) // not supported with ktlint 0.48+
     baseline.set(file("my-project-ktlint-baseline.xml"))
     reporters {
         reporter(ReporterType.PLAIN)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -99,6 +99,7 @@ internal constructor(
     /**
      * Provide additional `.editorconfig` file, that are not in the project or project parent folders.
      */
+    @Deprecated("not supported with ktlint 0.47+")
     val additionalEditorconfigFile: RegularFileProperty = objectFactory.fileProperty()
 
     /**
@@ -106,6 +107,7 @@ internal constructor(
      *
      * @since ktlint `0.34.2`
      */
+    @Deprecated("not supported with ktlint 0.48+")
     val disabledRules: SetProperty<String> = objectFactory.setProperty {
         set(emptySet())
     }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -37,7 +37,11 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
 
         val result = mutableListOf<LintErrorResult>()
         val formattedFiles = mutableMapOf<File, ByteArray>()
-
+        if (parameters.additionalEditorconfigFile.isPresent &&
+            parameters.ktLintVersion.map { SemVer.parse(it) }.get() >= SemVer(0, 47)
+        ) {
+            logger.warn("additionalEditorconfigFile no longer supported in ktlint 0.47+")
+        }
         val ktlintInvoker: KtLintInvocation = when (val ktlintInvokerFactory = selectInvocation()) {
             is LegacyParamsInvocation.Factory -> {
                 ktlintInvokerFactory.initialize(

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/testDsl.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/testDsl.kt
@@ -59,6 +59,18 @@ class TestProject(
         )
     }
 
+    fun withAdditionalEditorConfig() {
+        createSourceFile(
+            ADDITIONAL_EDITOR_CONFIG + "/.editorconfig",
+            """
+            |[*.kt]
+            |disabled_rules = no-multi-spaces
+            |ktlint_disabled_rules = no-multi-spaces
+            |ktlint_standard_no-multi-spaces = disabled
+            """.trimMargin()
+        )
+    }
+
     fun withCleanKotlinScript() {
         createSourceFile(
             "kotlin-script.kts",
@@ -103,6 +115,7 @@ class TestProject(
     companion object {
         const val CLEAN_SOURCES_FILE = "src/main/kotlin/CleanSource.kt"
         const val FAIL_SOURCE_FILE = "src/main/kotlin/FailSource.kt"
+        const val ADDITIONAL_EDITOR_CONFIG = "AdditionalEditorConfig"
     }
 }
 


### PR DESCRIPTION
test additionalEditorconfigFile for all ktlint versions