### PR TITLE
Support disabledRules for ktlint version 0.48.x

### DIFF
--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation.kt
@@ -181,7 +181,7 @@ private fun experimentalUserDataToEditorConfigOverride(userData: Map<String, Str
 
 private fun <T> createEditorConfigProperty(
     name: String,
-    @Suppress("SameParameterValue") value: T,
+    value: T,
 ): Any {
     val editorConfigClass = getEditorConfigPropertyClass()
     val type = PropertyType.LowerCasingPropertyType(
@@ -218,7 +218,7 @@ private fun userDataToEditorConfigOverride(userData: Map<String, String>): Any {
         .forEach {
             addMethod.invoke(
                 editorConfigOverride,
-                createEditorConfigProperty(it, "disabled"),
+                createEditorConfigProperty(it, userData[it]),
                 userData[it]
             )
         }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -156,6 +156,15 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
         if (disabledRules.isNotEmpty()) {
             userData["disabled_rules"] = disabledRules.joinToString(separator = ",")
         }
+        if (SemVer.parse(parameters.ktLintVersion.get()) < SemVer(0, 48, 0)) {
+            if (disabledRules.isNotEmpty()) {
+                userData["disabled_rules"] = disabledRules.joinToString(separator = ",")
+            }
+        } else {
+            disabledRules.forEach {
+                userData["ktlint_standard_$it"] = "disabled"
+            }
+        }
 
         return userData.toMap()
     }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/DisabledRulesTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/DisabledRulesTest.kt
@@ -53,7 +53,7 @@ class DisabledRulesTest : AbstractPluginTest() {
                     assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                     assertThat(output)
                         .`as`("old disabled_rules list is deprecated in 0.48, slated for removal in 0.49")
-                        .contains("Property 'ktlint_disabled_rules' is deprecated")
+                        .doesNotContain("Property 'ktlint_disabled_rules' is deprecated")
                 }
             }
         }


### PR DESCRIPTION
Using disabledRules gives this same warning.
https://github.com/JLLeitschuh/ktlint-gradle/issues/622

changed `disabled_rules` to `ktlint_standard_${ruleName}` for ktlint version 0.48.x.
https://github.com/pinterest/ktlint/commit/4d273d0f89bd8a36d27f17cc591634fb1bb971e4

I am not using `ktlint_experimental` and `custom-rule`. I have not implemented them because I cannot check the use case.