### PR TITLE
Add failing test for source exclusion with pattern

### DIFF
--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -186,7 +186,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             buildGradle.appendText(
                 """
 
-                ktlint.filter { exclude("**/FailSource.kt") }
+                ktlint.filter { exclude("**/src/**/Fail*.kt") }
                 """.trimIndent()
             )
 


### PR DESCRIPTION
Follow-up to https://github.com/JLLeitschuh/ktlint-gradle/issues/579#issuecomment-1495039473.

This failing test represents my understanding of the bug from https://github.com/JLLeitschuh/ktlint-gradle/issues/579#issuecomment-1184532934.

1. **Given** a file `plugin-test/src/main/kotlin/FailSource.kt`containing formatting violations,
2. and supposing that the file pattern indeed 'anchors' on the project root 'plugin-test',
3. and given the exclusion pattern `**/src/**/Fail*.kt`
4. **when** running the format task
5. **then** ktlint-gradle ignores the formatting violations.

<details>
<summary>Output of the test failure (click to expand)</summary>

    org.gradle.testkit.runner.UnexpectedBuildFailure: Unexpected build execution failure in /var/folders/38/2_cb64ts7t582nv66gr7z_3w0000gn/T/junit8746447825079381523/plugin-test with arguments [ktlintCheck, --stacktrace]

    Output:
    > Task :loadKtlintReporters
    > Task :runKtlintCheckOverKotlinScripts NO-SOURCE
    > Task :ktlintKotlinScriptCheck SKIPPED
    > Task :runKtlintCheckOverTestSourceSet NO-SOURCE
    > Task :ktlintTestSourceSetCheck SKIPPED
    > Task :runKtlintCheckOverMainSourceSet

    > Task :ktlintMainSourceSetCheck FAILED
    /private/var/folders/38/2_cb64ts7t582nv66gr7z_3w0000gn/T/junit8746447825079381523/plugin-test/src/main/kotlin/FailSource.kt:1:5 Unnecessary long whitespace
    /private/var/folders/38/2_cb64ts7t582nv66gr7z_3w0000gn/T/junit8746447825079381523/plugin-test/src/main/kotlin/FailSource.kt:1:10 Unnecessary long whitespace
    /private/var/folders/38/2_cb64ts7t582nv66gr7z_3w0000gn/T/junit8746447825079381523/plugin-test/src/main/kotlin/FailSource.kt:1:15 Unnecessary long whitespace

    FAILURE: Build failed with an exception.

    * What went wrong:
    Execution failed for task ':ktlintMainSourceSetCheck'.
    > A failure occurred while executing org.jlleitschuh.gradle.ktlint.worker.ConsoleReportWorkAction
       > KtLint found code style violations. Please see the following reports:
         - /private/var/folders/38/2_cb64ts7t582nv66gr7z_3w0000gn/T/junit8746447825079381523/plugin-test/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt


</details>