### PR TITLE
ktlint 0.50.0 support (fixes #686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 -   update latest version text file manually [#685](https://github.com/JLLeitschuh/ktlint-gradle/pull/685)
+-   ktlint 0.50.0 compatibility [#687](https://github.com/JLLeitschuh/ktlint-gradle/pull/687)
 
 ## [11.4.2] - 2023-06-22
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -85,7 +85,20 @@ sourceSets {
     val adapter49 by creating {
         compileClasspath += adapter.output
     }
-    val adapters = listOf(adapter, adapter34, adapter41, adapter45, adapter46, adapter47, adapter48, adapter49)
+    val adapter50 by creating {
+        compileClasspath += adapter.output
+    }
+    val adapters = listOf(
+        adapter,
+        adapter34,
+        adapter41,
+        adapter45,
+        adapter46,
+        adapter47,
+        adapter48,
+        adapter49,
+        adapter50
+    )
     val main by getting {
         kotlin {
             compileClasspath = adapters.map { it.output }.fold(compileClasspath) { a, b -> a + b }
@@ -107,7 +120,8 @@ val adapterSources = listOf(
     sourceSets.named("adapter46"),
     sourceSets.named("adapter47"),
     sourceSets.named("adapter48"),
-    sourceSets.named("adapter49")
+    sourceSets.named("adapter49"),
+    sourceSets.named("adapter50")
 )
 tasks.named<Jar>("shadowJar") {
     this.from(adapterSources.map { sourceSet -> sourceSet.map { it.output.classesDirs } })
@@ -133,11 +147,18 @@ dependencies {
     add("adapter46CompileOnly", "com.pinterest.ktlint:ktlint-core:0.46.1")
     add("adapter47CompileOnly", "com.pinterest.ktlint:ktlint-core:0.47.1")
     add("adapter48CompileOnly", "com.pinterest.ktlint:ktlint-core:0.48.2")
+
     add("adapter49CompileOnly", "com.pinterest.ktlint:ktlint-core:0.49.1")
     add("adapter49CompileOnly", "com.pinterest.ktlint:ktlint-cli-reporter:0.49.1")
     add("adapter49CompileOnly", "com.pinterest.ktlint:ktlint-rule-engine:0.49.1")
     add("adapter49CompileOnly", "com.pinterest.ktlint:ktlint-ruleset-standard:0.49.1")
     add("adapter49CompileOnly", "com.pinterest.ktlint:ktlint-reporter-baseline:0.49.1")
+
+    add("adapter50CompileOnly", "com.pinterest.ktlint:ktlint-cli-reporter:0.50.0")
+    add("adapter50CompileOnly", "com.pinterest.ktlint:ktlint-rule-engine:0.50.0")
+    add("adapter50CompileOnly", "com.pinterest.ktlint:ktlint-ruleset-standard:0.50.0")
+    add("adapter50CompileOnly", "com.pinterest.ktlint:ktlint-reporter-baseline:0.50.0")
+
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.android.gradle.plugin)
     compileOnly(kotlin("stdlib-jdk8"))

--- a/plugin/src/adapter50/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation50.kt
+++ b/plugin/src/adapter50/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation50.kt
@@ -1,0 +1,45 @@
+package org.jlleitschuh.gradle.ktlint.worker
+
+import com.pinterest.ktlint.rule.engine.api.Code
+import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
+import com.pinterest.ktlint.rule.engine.api.LintError
+import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider
+import java.io.File
+
+class KtLintInvocation50(
+    private val engine: KtLintRuleEngine
+) : KtLintInvocation {
+    companion object Factory : KtLintInvocationFactory {
+        fun initialize(): KtLintInvocation {
+            val engine = KtLintRuleEngine(
+                ruleProviders = StandardRuleSetProvider().getRuleProviders()
+            )
+            return KtLintInvocation50(engine)
+        }
+    }
+
+    override fun invokeLint(file: File): LintErrorResult {
+        val errors = mutableListOf<Pair<SerializableLintError, Boolean>>()
+        engine.lint(Code.fromFile(file)) { le: LintError ->
+            errors.add(le.toSerializable() to false)
+        }
+        return LintErrorResult(file, errors)
+    }
+
+    override fun invokeFormat(file: File): Pair<String, LintErrorResult> {
+        val errors = mutableListOf<Pair<SerializableLintError, Boolean>>()
+        val newCode =
+            engine.format(Code.fromFile(file)) { le, boolean ->
+                errors.add(le.toSerializable() to boolean)
+            }
+        return newCode to LintErrorResult(file, errors)
+    }
+
+    override fun trimMemory() {
+        engine.trimMemory()
+    }
+}
+
+internal fun LintError.toSerializable(): SerializableLintError {
+    return SerializableLintError(line, col, ruleId.value, detail, canBeAutoCorrected)
+}

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtLintCompatibility.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtLintCompatibility.kt
@@ -17,6 +17,7 @@ import org.jlleitschuh.gradle.ktlint.worker.KtLintInvocation46
 import org.jlleitschuh.gradle.ktlint.worker.KtLintInvocation47
 import org.jlleitschuh.gradle.ktlint.worker.KtLintInvocation48
 import org.jlleitschuh.gradle.ktlint.worker.KtLintInvocation49
+import org.jlleitschuh.gradle.ktlint.worker.KtLintInvocation50
 import org.jlleitschuh.gradle.ktlint.worker.KtLintInvocationFactory
 import java.io.Serializable
 
@@ -31,11 +32,13 @@ internal fun selectInvocation(version: String): KtLintInvocationFactory {
             KtLintInvocation47
         } else if (semVer.minor == 48) {
             KtLintInvocation48
-        } else {
+        } else if (semVer.minor == 49) {
             KtLintInvocation49
+        } else {
+            KtLintInvocation50
         }
     } else {
-        KtLintInvocation49
+        KtLintInvocation50
     }
 }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -85,6 +85,9 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
                 ktlintInvokerFactory.initialize()
             }
 
+            is KtLintInvocation50.Factory -> {
+                ktlintInvokerFactory.initialize()
+            }
             else -> {
                 throw GradleException("Incompatible ktlint version ${parameters.ktLintVersion}")
             }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -153,7 +153,8 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             "0.48.1",
             "0.48.2",
             // "0.49.0" did not expose needed baseline classes
-            "0.49.1"
+            "0.49.1",
+            "0.50.0"
         ).also {
             // "0.37.0" is failing on Windows machines that is fixed in the next version
             if (!OS.WINDOWS.isCurrentOs) it.add("0.37.0")


### PR DESCRIPTION
the ktlint changes were source-compatible but not bytecode compatible because of the use of optional parameters in the KtLintRuleEngine constructor