### PR TITLE
Fix for "Kotlin `sourceDir` isn't take into account"

### DIFF
--- a/plugin/gradle/libs.versions.toml
+++ b/plugin/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.5.31"
 ktlint = "0.47.1" # last version prior to API changes. we can increase this more once we drop support for the old API.
-androidPlugin = "4.1.0"
+androidPlugin = "7.0.0"
 semver = "1.1.1"
 jgit = "5.6.0.201912101111-r"
 sl4fj = "1.7.30"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/android/AndroidPluginsApplier.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/android/AndroidPluginsApplier.kt
@@ -1,14 +1,10 @@
 package org.jlleitschuh.gradle.ktlint.android
 
-import com.android.build.api.dsl.AndroidSourceSet
 import com.android.build.api.dsl.BuildFeatures
 import com.android.build.api.dsl.BuildType
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.DefaultConfig
 import com.android.build.api.dsl.ProductFlavor
-import com.android.build.api.dsl.SigningConfig
-import com.android.build.api.variant.Variant
-import com.android.build.api.variant.VariantProperties
 import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
 import org.gradle.api.Plugin
 import org.gradle.api.file.FileCollection
@@ -43,17 +39,8 @@ internal fun KtlintPlugin.PluginHolder.applyKtLintToAndroid(): (Plugin<in Any>) 
     }
 }
 
-@Suppress("UnstableApiUsage")
-private typealias AndroidCommonExtension = CommonExtension<
-    AndroidSourceSet,
-    BuildFeatures,
-    BuildType,
-    DefaultConfig,
-    ProductFlavor,
-    SigningConfig,
-    Variant<VariantProperties>,
-    VariantProperties
-    >
+private typealias AndroidCommonExtension =
+    CommonExtension<BuildFeatures, BuildType, DefaultConfig, ProductFlavor>
 
 /*
  * Variant manager returns all sources for variant,
@@ -69,7 +56,7 @@ private fun androidPluginConfigureAction(
 
         androidCommonExtension.sourceSets.all {
             // https://issuetracker.google.com/u/1/issues/170650362
-            val androidSourceSet = java as DefaultAndroidSourceDirectorySet
+            val androidSourceSet = kotlin as DefaultAndroidSourceDirectorySet
             // Passing Callable, so returned FileCollection, will lazy evaluate it
             // only when task will need it.
             // Solves the problem of having additional source dirs in


### PR DESCRIPTION
Closes #702 

### Description:

An detailed explanation *why* can be read in #702 

I also had the upgrade the AGP to version 7.0.0 because the 4.1.0 doesn't know the `kotlin` property 😁 
7.0.0 is the first version that supports hit.
Yes, this would be an potential breaking change.
But please take a look at the release dates for those plugins:
https://maven.google.com/web/index.html?q=tools.bui#com.android.tools.build:gradle:4.1.0 
-> Release at 10th December 2020

https://maven.google.com/web/index.html?q=tools.bui#com.android.tools.build:gradle:7.0.0
-> Release at 28th July 2021

As the Android community is normaly quite good in upgrading the *core* plugin to develop, I guess we are fine 😁 

### Changes:
* Upgrade Android Gradle Plugin from 4.1.0 to 7.0.0
* Use `kotlin` sourceSet instead of `java` sourceSet

### How to test:
1. Change the version in `/plugin/VERSION_CURRENT.txt` to something else e.g. "testKotlinSourceSet"
2. 
```shell
cd plugin 
./gradlew publishToMavenLocal
```
3. Include the `mavenLocal()` repository (to find that version)
4. Replace the current ktlint-plugin version (in your project) with the one you change din the `/plugin/VERSION_CURRENT.txt`
