### PR TITLE
 improve error logging (fixes #710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 -   update latest version text file manually [#709](https://github.com/JLLeitschuh/ktlint-gradle/pull/709)
+-   Improve error logging [#711](https://github.com/JLLeitschuh/ktlint-gradle/pull/711)
 
 ## [11.6.0] - 2023-09-18
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -123,6 +123,7 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
                     results.add(result)
                 }
             } catch (e: RuntimeException) {
+                logger.error(e.message)
                 throw GradleException(
                     "KtLint failed to parse file: ${it.absolutePath}",
                     e


### PR DESCRIPTION
send an error log to the logger when catching an exception from ktlint before throwing the gradle exception

fixes #710