### PR TITLE
fix "additionalEditorconfig not supported until ktlint 0.49" warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+-   fix "additionalEditorconfig not supported until ktlint 0.49" warning [#712](https://github.com/JLLeitschuh/ktlint-gradle/pull/712)
 -   update latest version text file manually [#709](https://github.com/JLLeitschuh/ktlint-gradle/pull/709)
 -   Improve error logging [#711](https://github.com/JLLeitschuh/ktlint-gradle/pull/711)
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -40,6 +40,7 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
             logger.warn("additionalEditorconfigFile no longer supported in ktlint 0.47+")
         }
         if (parameters.additionalEditorconfig.isPresent &&
+            parameters.additionalEditorconfig.get().isNotEmpty() &&
             parameters.ktLintVersion.map { SemVer.parse(it) }.get() < SemVer(0, 49)
         ) {
             logger.warn("additionalEditorconfig not supported until ktlint 0.49")

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -94,10 +94,12 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
                 buildAndFail(CHECK_PARENT_TASK_NAME) {
                     assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
                     assertThat(output).contains("additionalEditorconfigFile no longer supported in ktlint 0.47+")
+                    assertThat(output).doesNotContain("additionalEditorconfig not supported until ktlint 0.49")
                 }
             } else {
                 build(CHECK_PARENT_TASK_NAME) {
                     assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+                    assertThat(output).doesNotContain("additionalEditorconfig not supported until ktlint 0.49")
                 }
             }
         }


### PR DESCRIPTION
fix "additionalEditorconfig not supported until ktlint 0.49" warning when additionalEditorconfig is not being used