### PR TITLE
Fix configuration cache for relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 -   update latest version text file manually [#716](https://github.com/JLLeitschuh/ktlint-gradle/pull/716)
+-   Fix configuration cache for relative paths [#722](https://github.com/JLLeitschuh/ktlint-gradle/pull/722)
 
 ## [11.6.1] - 2023-10-10
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateReportsTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/GenerateReportsTask.kt
@@ -90,6 +90,13 @@ abstract class GenerateReportsTask @Inject constructor(
     @get:Optional
     internal abstract val baseline: RegularFileProperty
 
+    /**
+     * Reading a project's rootDir within a task's action is not allowed for configuration
+     * cache, so read it eagerly on task initialization.
+     * see: https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache
+     */
+    private val rootDir: File = project.rootDir
+
     init {
         // Workaround for https://github.com/gradle/gradle/issues/2919
         onlyIf {
@@ -142,7 +149,7 @@ abstract class GenerateReportsTask @Inject constructor(
                 param.baseline.set(baseline)
                 param.projectDirectory.set(projectLayout.projectDirectory)
                 if (relative.get()) {
-                    param.filePathsRelativeTo.set(project.rootDir)
+                    param.filePathsRelativeTo.set(rootDir)
                 }
             }
         }


### PR DESCRIPTION
resolves #721 

The new test would fail before the changes to generate reports task and succeed afterwards