### PR TITLE
remove KtLintIdea Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+-  remove KtLintIdea Plugin [#726](https://github.com/JLLeitschuh/ktlint-gradle/pull/726).
+   This plugin is no longer needed as ktlint configuration is driven by .editorconfig now, which IDEA will respect out of the box.
+
 ## [12.0.1] - 2023-11-30
 
 -   update configure-pagefile-action task [#725](https://github.com/JLLeitschuh/ktlint-gradle/pull/725)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -308,11 +308,6 @@ gradlePlugin {
             implementationClass = "org.jlleitschuh.gradle.ktlint.KtlintPlugin"
             displayName = "Ktlint Gradle Plugin"
         }
-        register("ktlintIdeaPlugin") {
-            id = "org.jlleitschuh.gradle.ktlint-idea"
-            implementationClass = "org.jlleitschuh.gradle.ktlint.KtlintIdeaPlugin"
-            displayName = "Ktlint Gradle IDEA Plugin"
-        }
     }
 }
 


### PR DESCRIPTION
This plugin is no longer needed as ktlint configuration is driven by .editorconfig now, which idea will respect out of the box

The plugin was already removed in 12.0.0, but we need to remove the declaration of the plugin in the build scripts to pass validation