### PR TITLE
fix: apply configuration for source sets and targets that are added after the plugin is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- fix: apply configuration for source sets and targets that are added after the plugin is
+  applied [#732](https://github.com/JLLeitschuh/ktlint-gradle/pull/732)
+
 ## [12.0.2] - 2023-12-01
 
 -   remove KtLintIdea Plugin [#726](https://github.com/JLLeitschuh/ktlint-gradle/pull/726).

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -39,7 +39,7 @@ open class KtlintPlugin : Plugin<Project> {
     private fun PluginHolder.applyKtlintMultiplatform(): (Plugin<in Any>) -> Unit = {
         val multiplatformExtension = target.extensions.getByType(KotlinMultiplatformExtension::class.java)
 
-        multiplatformExtension.sourceSets.forEach { sourceSet ->
+        multiplatformExtension.sourceSets.all(fun(sourceSet) {
             val checkTask = createCheckTask(
                 this,
                 sourceSet.name,
@@ -68,18 +68,18 @@ open class KtlintPlugin : Plugin<Project> {
             )
 
             addGenerateReportsTaskToProjectMetaFormatTask(generateReportsFormatTask)
-        }
+        })
 
-        multiplatformExtension.targets.forEach { kotlinTarget ->
+        multiplatformExtension.targets.all(fun(kotlinTarget) {
             if (kotlinTarget.platformType == KotlinPlatformType.androidJvm) {
                 applyKtLintToAndroid()
             }
-        }
+        })
     }
 
     private fun PluginHolder.applyKtLint(): (Plugin<in Any>) -> Unit = {
         target.extensions.configure(KotlinProjectExtension::class.java) {
-            sourceSets.forEach { sourceSet ->
+            sourceSets.all(fun(sourceSet) {
                 val kotlinSourceDirectories = sourceSet.kotlin.sourceDirectories
                 val checkTask = createCheckTask(
                     this@applyKtLint,
@@ -109,7 +109,7 @@ open class KtlintPlugin : Plugin<Project> {
                 )
 
                 addGenerateReportsTaskToProjectMetaFormatTask(generateReportsFormatTask)
-            }
+            })
         }
     }
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KotlinMultiplatformPluginTests.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KotlinMultiplatformPluginTests.kt
@@ -1,0 +1,70 @@
+package org.jlleitschuh.gradle.ktlint
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.util.GradleVersion
+import org.jlleitschuh.gradle.ktlint.tasks.GenerateReportsTask
+import org.jlleitschuh.gradle.ktlint.testdsl.CommonTest
+import org.jlleitschuh.gradle.ktlint.testdsl.GradleTestVersions
+import org.jlleitschuh.gradle.ktlint.testdsl.build
+import org.jlleitschuh.gradle.ktlint.testdsl.project
+import org.jlleitschuh.gradle.ktlint.testdsl.projectSetup
+import org.junit.jupiter.api.DisplayName
+import java.io.File
+
+/**
+ * Contains all tests related to "org.jetbrains.kotlin.multiplatform" plugin support.
+ */
+@GradleTestVersions
+class KotlinMultiplatformPluginTests : AbstractPluginTest() {
+    private fun multiplatformProjectSetup(gradleVersion: GradleVersion): (File) -> Unit = {
+        projectSetup("multiplatform", gradleVersion).invoke(it)
+
+        //language=Groovy
+        it.resolve("build.gradle").appendText(
+            """
+            |
+            |kotlin {
+            |    js {
+            |      browser()
+            |    }
+            |    jvm()
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @DisplayName("Should add check on all sources")
+    @CommonTest
+    fun addCheckTasks(gradleVersion: GradleVersion) {
+        project(gradleVersion, projectSetup = multiplatformProjectSetup(gradleVersion)) {
+            build("-m", CHECK_PARENT_TASK_NAME) {
+                val ktlintTasks = output.lineSequence().toList()
+
+                assertThat(ktlintTasks).anySatisfy {
+                    assertThat(it).contains(
+                        GenerateReportsTask.generateNameForSourceSets(
+                            "commonMain",
+                            GenerateReportsTask.LintType.CHECK
+                        )
+                    )
+                }
+                assertThat(ktlintTasks).anySatisfy {
+                    assertThat(it).contains(
+                        GenerateReportsTask.generateNameForSourceSets(
+                            "JsMain",
+                            GenerateReportsTask.LintType.CHECK
+                        )
+                    )
+                }
+                assertThat(ktlintTasks).anySatisfy {
+                    assertThat(it).contains(
+                        GenerateReportsTask.generateNameForSourceSets(
+                            "JvmMain",
+                            GenerateReportsTask.LintType.CHECK
+                        )
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use `DomainObjectCollection.all` instead of `Iterable<T>.forEach`. `all` executes the given function also against any objects subsequently added objects

The problem was introduced here
https://github.com/JLLeitschuh/ktlint-gradle/commit/a547de5601caec50ed827b1a5fe6c8207d41d218?diff=unified&w=0#diff-51eee411b698815c113da41ed3e9f5c31ebc7cb926df3580835df154cdd721e0L45