### PR TITLE
Add Version Catalog Setup Instructions in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 -   builds: remove specific lintian version, as latest ubuntu is now a new version
     [#767](https://github.com/JLLeitschuh/ktlint-gradle/pull/767)
+    
+-   docs: add Version Catalog setup instructions in README
+    [#770](https://github.com/JLLeitschuh/ktlint-gradle/pull/770)
 
 ## [12.1.1] - 2024-05-07
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,49 @@ repositories {
 ```
 </details>
 
+#### Using Version Catalog
+
+To configure the plugin using a version catalog, first, add the following entries to your libs.versions.toml file:
+
+```toml
+[versions]
+ktlint = "<current_version>"
+
+[plugins]
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+```
+
+Next, apply it to your project:
+
+<details>
+<summary>Groovy</summary>
+
+```groovy
+plugins {
+  alias(libs.plugins.ktlint)
+}
+
+repositories {
+  // Required to download KtLint
+  mavenCentral()
+}
+```
+</details>
+<details open>
+<summary>Kotlin</summary>
+
+```kotlin
+plugins {
+  alias(libs.plugins.ktlint)
+}
+
+repositories {
+  // Required to download KtLint
+  mavenCentral()
+}
+```
+</details>
+
 #### Using legacy apply method
 
 Build script snippet for use in all Gradle versions:


### PR DESCRIPTION
This update supplements the documentation by adding instructions for configuring the Ktlint Gradle plugin using a version catalog. 

Since using version catalogs is now recommended officially and is used by default in newly generated projects, this addition provides essential guidance for both Groovy and Kotlin DSL users, making it easier to integrate the plugin into modern project setups.