### PR TITLE
fix tests which relied on a third party reporter in jcenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ gradle-app.setting
 # End of https://www.gitignore.io/api/eclipse,gradle,intellij,vim,java
 
 .gradle-test-kit
+.obsidian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-- Update version for jgit to 5.13.3.202401111512-r [#766](https://github.com/JLLeitschuh/ktlint-gradle/pull/766)
 
--   builds: remove specific lintian version, as latest ubuntu is now a new version
+- Update version for jgit to 5.13.3.202401111512-r [#766](https://github.com/JLLeitschuh/ktlint-gradle/pull/766)
+- builds: remove specific lintian version, as latest ubuntu is now a new version
     [#767](https://github.com/JLLeitschuh/ktlint-gradle/pull/767)
+- fix tests which relied on a third party reporter in jcenter [#772](https://github.com/JLLeitschuh/ktlint-gradle/pull/772)
 
 ## [12.1.1] - 2024-05-07
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/BuildCacheTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/BuildCacheTest.kt
@@ -8,7 +8,9 @@ import org.jlleitschuh.gradle.ktlint.testdsl.CommonTest
 import org.jlleitschuh.gradle.ktlint.testdsl.GradleTestVersions
 import org.jlleitschuh.gradle.ktlint.testdsl.TestProject
 import org.jlleitschuh.gradle.ktlint.testdsl.build
+import org.jlleitschuh.gradle.ktlint.testdsl.getMajorJavaVersion
 import org.jlleitschuh.gradle.ktlint.testdsl.project
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.DisplayName
 import java.io.File
 
@@ -47,6 +49,8 @@ class BuildCacheTest : AbstractPluginTest() {
     @DisplayName("Check task with additional reporters should be relocatable")
     @CommonTest
     fun checkWithReportersIsRelocatable(gradleVersion: GradleVersion) {
+        // custom reporter is compiled on java 11
+        Assumptions.assumeTrue(getMajorJavaVersion() >= 11)
         project(gradleVersion, projectPath = originalRoot) {
             configureDefaultProject()
             useExternalKtLintReporter()
@@ -70,18 +74,12 @@ class BuildCacheTest : AbstractPluginTest() {
         .appendText(
             //language=Groovy
             """
-
-            repositories {
-                jcenter()
-            }
-
             ktlint.reporters {
                 reporter "plain"
                 reporter "checkstyle"
                 customReporters {
-                    "html" {
-                        fileExtension = "html"
-                        dependency = "me.cassiano:ktlint-html-reporter:0.2.3"
+                    "github" {
+                        dependency = "de.musichin.ktlint.reporter:ktlint-reporter-github:3.1.0"
                     }
                 }
             }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ConfigurationCacheTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ConfigurationCacheTest.kt
@@ -75,10 +75,6 @@ class ConfigurationCacheTest : AbstractPluginTest() {
             buildGradle.appendText(
                 //language=Groovy
                 """
-                repositories {
-                    jcenter()
-                }
-
                 ktlint {
                     relative = true
                     reporters {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
@@ -9,7 +9,9 @@ import org.jlleitschuh.gradle.ktlint.testdsl.GradleTestVersions
 import org.jlleitschuh.gradle.ktlint.testdsl.TestProject
 import org.jlleitschuh.gradle.ktlint.testdsl.build
 import org.jlleitschuh.gradle.ktlint.testdsl.buildAndFail
+import org.jlleitschuh.gradle.ktlint.testdsl.getMajorJavaVersion
 import org.jlleitschuh.gradle.ktlint.testdsl.project
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.DisplayName
 
 @GradleTestVersions
@@ -44,23 +46,18 @@ class ReportersTest : AbstractPluginTest() {
     @DisplayName("Should create 3rd party report")
     @CommonTest
     internal fun thirdPartyReport(gradleVersion: GradleVersion) {
-        // TODO: switch to some 3rd party reporter that is published to Maven Central
+        // custom reporter is compiled on java 11
+        Assumptions.assumeTrue(getMajorJavaVersion() >= 11)
         project(gradleVersion) {
             // https://github.com/mcassiano/ktlint-html-reporter/releases
             //language=Groovy
             buildGradle.appendText(
                 """
-
-                repositories {
-                    jcenter()
-                }
-
                 ktlint.reporters {
                     reporter "checkstyle"
                     customReporters {
-                        "html" {
-                            fileExtension = "html"
-                            dependency = "me.cassiano:ktlint-html-reporter:0.2.3"
+                        "github" {
+                            dependency = "de.musichin.ktlint.reporter:ktlint-reporter-github:3.1.0"
                         }
                     }
                 }
@@ -74,7 +71,7 @@ class ReportersTest : AbstractPluginTest() {
                 assertReportCreated(ReporterType.CHECKSTYLE.fileExtension, mainSourceSetCheckTaskName)
                 assertReportNotCreated(ReporterType.PLAIN.fileExtension, mainSourceSetCheckTaskName)
                 assertReportNotCreated(ReporterType.JSON.fileExtension, mainSourceSetCheckTaskName)
-                assertReportCreated("html", mainSourceSetCheckTaskName)
+                assertReportCreated("github", mainSourceSetCheckTaskName)
             }
         }
     }


### PR DESCRIPTION
fix tests which relied on a third party reporter in jcenter to use a third party reporter published to maven central (fixes #771)