### PR TITLE
pre-commit hook : fix losing unstaged files on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 
 
+### Fixed
+
+- Force the pre-commit script to continue even if there is error to ensure the unstaged files are reapplied. [#814](https://github.com/JLLeitschuh/ktlint-gradle/pull/814)
+
 ## [12.2.0] - 2025-02-27
 
 - Update Gradle wrapper and Gradle versions for testing. [#819](https://github.com/JLLeitschuh/ktlint-gradle/pull/819)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -70,7 +70,7 @@ internal fun generateGitHook(
     gradleRootDirPrefix: String
 ) =
     """
-
+    set +e
     CHANGED_FILES="${'$'}(${generateGitCommand(gradleRootDirPrefix)} | awk '$1 != "D" && $NF ~ /\.kts?$/ { print $NF }')"
 
     if [ -z "${'$'}CHANGED_FILES" ]; then


### PR DESCRIPTION
Force the pre-commit script to continue even if there is error to ensure the unstaged files are reapplied.

It seems that in some case/environment the commit hook is launched with set -e. In this case, the unstaged files are not reapplied and can be lost.
