### PR TITLE
Fix dependency issue for git hook tasks

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install checkbashisms
         run: sudo apt-get install -qq devscripts
       - name: Check git bashisms
-        run: ./gradlew addKtlintCheckGitPreCommitHook --no-daemon && checkbashisms .git/hooks/pre-commit
+        run: ./gradlew compileKotlin addKtlintCheckGitPreCommitHook --no-daemon && checkbashisms .git/hooks/pre-commit
 
   check_samples:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 
 
+### Fixed
+
+- Fix `addKtlintCheckGitPreCommitHook` task marking the entire project root and contents as input ([#837](https://github.com/JLLeitschuh/ktlint-gradle/pull/837))
+
 ## [12.2.0] - 2025-02-27
 
 - Update Gradle wrapper and Gradle versions for testing. [#819](https://github.com/JLLeitschuh/ktlint-gradle/pull/819)

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -162,6 +162,11 @@ open class KtlintInstallGitHookTask @Inject constructor(
 
     @TaskAction
     fun installHook() {
+        /*
+         * Note: `projectDir` and `rootDirectory` are both using `Property<String>` instead
+         * of a `DirectoryProperty` because we want to rely upon the *path* not the *contents*
+         * https://github.com/JLLeitschuh/ktlint-gradle/pull/837
+         */
         val repo = RepositoryBuilder().findGitDir(File(projectDir.get())).setMustExist(false).build()
         if (!repo.objectDatabase.exists()) {
             logger.warn("No git folder was found!")

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -4,15 +4,14 @@ package org.jlleitschuh.gradle.ktlint
 
 import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.intellij.lang.annotations.Language
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
+import java.io.File
 import javax.inject.Inject
 
 internal const val FILTER_INCLUDE_PROPERTY_NAME = "internalKtlintGitFilter"
@@ -151,19 +150,19 @@ open class KtlintInstallGitHookTask @Inject constructor(
     @get:Input
     internal val hookName: Property<String> = objectFactory.property(String::class.java)
 
-    @get:InputDirectory
-    internal val projectDir: DirectoryProperty = objectFactory.directoryProperty().apply {
-        set(projectLayout.projectDirectory)
+    @get:Input
+    internal val projectDir: Property<String> = objectFactory.property(String::class.java).apply {
+        set(projectLayout.projectDirectory.asFile.absolutePath)
     }
 
-    @get:InputDirectory
-    internal val rootDirectory: DirectoryProperty = objectFactory.directoryProperty().apply {
-        set(project.rootDir)
+    @get:Input
+    internal val rootDirectory: Property<String> = objectFactory.property(String::class.java).apply {
+        set(project.rootDir.absolutePath)
     }
 
     @TaskAction
     fun installHook() {
-        val repo = RepositoryBuilder().findGitDir(projectDir.get().asFile).setMustExist(false).build()
+        val repo = RepositoryBuilder().findGitDir(File(projectDir.get())).setMustExist(false).build()
         if (!repo.objectDatabase.exists()) {
             logger.warn("No git folder was found!")
             return
@@ -182,7 +181,7 @@ open class KtlintInstallGitHookTask @Inject constructor(
             gitHookFile.createNewFile()
             gitHookFile.setExecutable(true)
         }
-        val gradleRootDirPrefix = rootDirectory.get().asFile.relativeTo(repo.workTree).path
+        val gradleRootDirPrefix = File(rootDirectory.get()).relativeTo(repo.workTree).path
 
         if (gitHookFile.length() == 0L) {
             gitHookFile.writeText(


### PR DESCRIPTION
When running one of the Git hook tasks together with another task, Gradle will complain with an error:

> Reason: Task ':addKtlintCheckGitPreCommitHook' uses this output of task ':samples:kotlin-reporter-using:compileKotlin' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

This is caused by `@InputDirectory` marking the entire project root and contents as input, so any task that modifies any file in the project will cause Gradle to add an implicit dependency.

You can see this behaviour by running `./gradlew compileKotlin addKtlintCheckGitPreCommitHook`.

Build result on the first commit of this PR, to show it failing: https://github.com/ntkoopman/ktlint-gradle/actions/runs/13514290368/job/37760683637

This is the same issue as https://github.com/JLLeitschuh/ktlint-gradle/pull/545, except this PR keeps the inputs.