### PR TITLE
Add maxRuleVersion configuration for version-based rule filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Add support for Android projects with new DSL i.e. built-in Kotlin [#1016](https://github.com/JLLeitschuh/ktlint-gradle/pull/1016)
 
+- Add maxRuleVersion configuration for version-based rule filtering [#943](https://github.com/JLLeitschuh/ktlint-gradle/pull/943)
+
 ## [14.0.1] - 2025-11-10
 
 - Update build to work with gradle 9.1 and Java 25 [#962](https://github.com/JLLeitschuh/ktlint-gradle/pull/962)

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ ktlint {
         "max_line_length": "20"
     ]
     disabledRules = ["final-newline"] // not supported with ktlint 0.48+
+    maxRuleVersion = "1.0.0" // Only include rules introduced up to this version
     baseline = file("my-project-ktlint-baseline.xml")
     reporters {
         reporter "plain"
@@ -367,6 +368,7 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
         )
     )
     disabledRules.set(setOf("final-newline")) // not supported with ktlint 0.48+
+    maxRuleVersion.set("1.0.0") // Only include rules introduced up to this version
     baseline.set(file("my-project-ktlint-baseline.xml"))
     reporters {
         reporter(ReporterType.PLAIN)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,7 +1,10 @@
 import com.github.breadmoirai.githubreleaseplugin.GithubReleaseTask
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.gradle.scan.agent.serialization.scan.serializer.kryo.it
+import okio.`-DeprecatedOkio`.source
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.internal.impldep.org.bouncycastle.asn1.x500.style.RFC4519Style.owner
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -47,10 +50,10 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-    compileOnly("com.pinterest.ktlint:ktlint-cli-reporter-core:1.0.0")
-    compileOnly("com.pinterest.ktlint:ktlint-rule-engine:1.0.0")
-    compileOnly("com.pinterest.ktlint:ktlint-ruleset-standard:1.0.0")
-    compileOnly("com.pinterest.ktlint:ktlint-cli-reporter-baseline:1.0.0")
+    compileOnly(libs.ktlint.cli.reporter.core)
+    compileOnly(libs.ktlint.rule.engine)
+    compileOnly(libs.ktlint.ruleset.standard)
+    compileOnly(libs.ktlint.cli.reporter.baseline)
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.android.gradle.plugin)
     compileOnly(kotlin("stdlib-jdk8"))
@@ -60,7 +63,8 @@ dependencies {
 
     testImplementation(libs.assertj.core)
     testImplementation(libs.kotlin.reflect)
-    testImplementation(libs.ktlint.rule.engine)
+    testImplementation(libs.ktlint.rule.engine.test)
+    testImplementation(libs.ktlint.rule.engine.core.test)
     testImplementation(libs.archunit.junit5)
 }
 
@@ -103,6 +107,9 @@ testing {
                     targets.all {
                         dependencies {
                             implementation(gradleTestKit())
+                            // Ensure that a custom ktlint version is used for tests
+                            implementation(libs.ktlint.rule.engine.test)
+                            implementation(libs.ktlint.rule.engine.core.test)
                         }
                         testTask.configure {
                             javaLauncher.set(

--- a/plugin/gradle/libs.versions.toml
+++ b/plugin/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.5.31"
 ktlint = "1.0.0"
+ktlintTest = "1.8.0"
 androidPlugin = "4.1.0"
 semver = "1.1.1"
 jgit = "5.13.3.202401111512-r"
@@ -20,6 +21,12 @@ jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-script-runtime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", version.ref = "kotlin" }
+ktlint-cli-reporter-baseline = { module = "com.pinterest.ktlint:ktlint-cli-reporter-baseline", version.ref = "ktlint" }
+ktlint-cli-reporter-core = { module = "com.pinterest.ktlint:ktlint-cli-reporter-core", version.ref = "ktlint" }
 ktlint-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlint" }
+ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint" }
+ktlint-ruleset-standard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }
+ktlint-rule-engine-test = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlintTest" }
+ktlint-rule-engine-core-test = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlintTest" }
 semver = { module = "net.swiftzer.semver:semver", version.ref = "semver" }
 slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "sl4fj" }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -100,6 +100,20 @@ open class KtlintExtension @Inject internal constructor(
     }
 
     /**
+     * Only include rules that were introduced in KtLint versions up to and including this version.
+     * When set, rules with @SinceKtlint annotations indicating they were added after this version will be excluded.
+     * Rules without the annotation (from older ktlint versions) are always included for backward compatibility.
+     *
+     * Format: "0.46.0", "0.47.1", etc.
+     * Default: null (no filtering - all rules are included)
+     *
+     * Example: `maxRuleVersion.set("0.46.0")` will exclude rules added in 0.47.0 and later.
+     *
+     * @since ktlint `1.8.0`
+     */
+    val maxRuleVersion: Property<String> = objectFactory.property(String::class.java)
+
+    /**
      * Provide additional `.editorconfig` properties, that are not in the project or project parent folders.
      */
     val additionalEditorconfig: MapProperty<String, String> =

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/TaskCreation.kt
@@ -136,6 +136,7 @@ private fun BaseKtLintCheckTask.configureBaseCheckTask(
     android.set(pluginHolder.extension.android)
     loadedReporters.set(pluginHolder.loadReportersTask.get().loadedReporters)
     enableExperimentalRules.set(pluginHolder.extension.enableExperimentalRules)
+    maxRuleVersion.set(pluginHolder.extension.maxRuleVersion)
 
     additionalTaskConfig()
 }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/tasks/BaseKtLintCheckTask.kt
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -79,6 +80,10 @@ abstract class BaseKtLintCheckTask @Inject constructor(
 
     @get:Input
     internal abstract val enableExperimentalRules: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    internal abstract val maxRuleVersion: Property<String>
 
     /**
      * Max lint worker heap size. Default is "256m".
@@ -279,6 +284,8 @@ abstract class BaseKtLintCheckTask @Inject constructor(
             ktLintVersion.set(task.ktLintVersion)
             editorconfigFilesWereChanged.set(editorConfigUpdated)
             this.formatSnapshot.set(formatSnapshot)
+            enableExperimentalRules.set(task.enableExperimentalRules)
+            maxRuleVersion.set(task.maxRuleVersion)
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation100.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation100.kt
@@ -7,6 +7,7 @@ import com.pinterest.ktlint.rule.engine.api.EditorConfigPropertyRegistry
 import com.pinterest.ktlint.rule.engine.api.KtLintRuleEngine
 import com.pinterest.ktlint.rule.engine.api.LintError
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import net.swiftzer.semver.SemVer
 import java.io.File
 import java.util.ServiceLoader
 
@@ -14,8 +15,12 @@ class KtLintInvocation100(
     private val engine: KtLintRuleEngine
 ) : KtLintInvocation {
     companion object Factory : KtLintInvocationFactory {
-        fun initialize(editorConfigOverrides: Map<String, String>): KtLintInvocation {
-            val ruleProviders = loadRuleSetsFromClasspathWithRuleSetProviderV3()
+        fun initialize(
+            editorConfigOverrides: Map<String, String>,
+            enableExperimentalRules: Boolean,
+            maxRuleVersion: String? = null
+        ): KtLintInvocation {
+            val ruleProviders = loadRuleSetsFromClasspathWithRuleSetProviderV3(enableExperimentalRules, maxRuleVersion)
             val editorConfigPropertyRegistry = EditorConfigPropertyRegistry(ruleProviders)
             val engine = if (editorConfigOverrides.isEmpty()) {
                 KtLintRuleEngine(ruleProviders = ruleProviders)
@@ -34,11 +39,87 @@ class KtLintInvocation100(
             return KtLintInvocation100(engine)
         }
 
-        private fun loadRuleSetsFromClasspathWithRuleSetProviderV3(): Set<RuleProvider> {
-            return ServiceLoader
+        private fun loadRuleSetsFromClasspathWithRuleSetProviderV3(enableExperimentalRules: Boolean, maxRuleVersion: String?): Set<RuleProvider> {
+            val allRuleProviders = ServiceLoader
                 .load(RuleSetProviderV3::class.java)
                 .flatMap { it.getRuleProviders() }
                 .toSet()
+
+            return if (maxRuleVersion != null || !enableExperimentalRules) {
+                filterRules(allRuleProviders, enableExperimentalRules, maxRuleVersion)
+            } else {
+                allRuleProviders
+            }
+        }
+
+        private fun filterRules(ruleProviders: Set<RuleProvider>, enableExperimentalRules: Boolean, maxVersion: String?): Set<RuleProvider> {
+            return ruleProviders.filter { ruleProvider ->
+                isRuleCompatibleWithFilters(ruleProvider, enableExperimentalRules, maxVersion)
+            }.toSet()
+        }
+
+        private const val SINCE_KTLINT_CLASS = "com.pinterest.ktlint.rule.engine.core.api.SinceKtlint"
+        private const val SINCE_KTLINT_STATUS_STABLE = "STABLE"
+
+        // TODO: When bumping ktlint compile dependency to 1.8.0+, replace reflection with direct
+        //  SinceKtlint import and use: ruleClass.getAnnotationsByType(SinceKtlint::class.java)
+
+        /**
+         * Determines if a rule should be included based on version and experimental filters.
+         *
+         * Uses reflection to access @SinceKtlint annotation, allowing this to work as a no-op
+         * on older ktlint versions where the annotation doesn't exist.
+         *
+         * A rule is compatible if ANY of its @SinceKtlint annotations satisfy BOTH:
+         * - Version constraint: rule version ≤ maxVersion (if maxVersion is set)
+         * - Experimental constraint: enableExperimentalRules = true OR annotation status = STABLE
+         *
+         * Rules without @SinceKtlint annotations are always included for backwards compatibility.
+         */
+        internal fun isRuleCompatibleWithFilters(ruleProvider: RuleProvider, enableExperimentalRules: Boolean, maxVersion: String?): Boolean {
+            val ruleClass = ruleProvider.createNewRuleInstance()::class.java
+
+            val sinceKtlintClass = try {
+                Class.forName(SINCE_KTLINT_CLASS)
+            } catch (_: ClassNotFoundException) {
+                // Annotation doesn't exist in this ktlint version
+                return true
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            val sinceAnnotations = ruleClass.getAnnotationsByType(sinceKtlintClass as Class<Annotation>)
+            if (sinceAnnotations.isEmpty()) {
+                return true
+            }
+
+            return sinceAnnotations.any { annotation ->
+                val version = sinceKtlintClass.getMethod("version").invoke(annotation).toString()
+                val status = sinceKtlintClass.getMethod("status").invoke(annotation).toString()
+                val versionCompatible = maxVersion == null || isVersionCompatible(version, maxVersion)
+                val experimentalCompatible = enableExperimentalRules || status == SINCE_KTLINT_STATUS_STABLE
+                versionCompatible && experimentalCompatible
+            }
+        }
+
+        /**
+         * Checks if a rule version is compatible with the specified maximum version.
+         *
+         * A rule is considered compatible if its version is less than or equal to the maximum version.
+         * Version comparison follows semantic versioning rules:
+         * - "0.46" <= "1.0.0" → true
+         * - "1.2.1" <= "1.2.0" → false
+         * - "1.0" <= "1.0.0" → true (missing parts treated as 0)
+         *
+         * @param ruleVersion The version when the rule was introduced (from @SinceKtlint annotation)
+         * @param maxVersion The maximum allowed version (from maxRuleVersion configuration)
+         * @return true if the rule version is compatible (should be included), false otherwise
+         */
+        private fun isVersionCompatible(ruleVersion: String, maxVersion: String): Boolean {
+            return try {
+                SemVer.parse(ruleVersion) <= SemVer.parse(maxVersion)
+            } catch (_: Exception) {
+                false
+            }
         }
     }
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintWorkAction.kt
@@ -29,7 +29,11 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
             val ktlintInvokerFactory = selectInvocation(parameters.ktLintVersion.get())
         ) {
             is KtLintInvocation100.Factory -> {
-                ktlintInvokerFactory.initialize(parameters.additionalEditorconfig.get())
+                ktlintInvokerFactory.initialize(
+                    parameters.additionalEditorconfig.get(),
+                    parameters.enableExperimentalRules.get(),
+                    parameters.maxRuleVersion.orNull
+                )
             }
 
             else -> {
@@ -97,6 +101,8 @@ abstract class KtLintWorkAction : WorkAction<KtLintWorkAction.KtLintWorkParamete
         val ktLintVersion: Property<String>
         val editorconfigFilesWereChanged: Property<Boolean>
         val formatSnapshot: RegularFileProperty
+        val enableExperimentalRules: Property<Boolean>
+        val maxRuleVersion: Property<String>
     }
 
     /**

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -728,4 +728,68 @@ dependencies {
             }
         }
     }
+
+    @DisplayName("Should allow setting maxRuleVersion")
+    @CommonTest
+    fun allowMaxRuleVersionConfiguration(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            withCleanSources()
+            //language=Groovy
+            buildGradle.appendText(
+                """
+                ktlint {
+                    version = "1.8.0"
+                    maxRuleVersion = "1.0.0"
+                }
+                """.trimIndent()
+            )
+
+            build(CHECK_PARENT_TASK_NAME) {
+                assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            }
+        }
+    }
+
+    @DisplayName("Should work without maxRuleVersion set")
+    @CommonTest
+    fun workWithoutMaxRuleVersion(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            withCleanSources()
+            //language=Groovy
+            buildGradle.appendText(
+                """
+                ktlint {
+                    version = "1.8.0"
+                }
+                """.trimIndent()
+            )
+
+            build(CHECK_PARENT_TASK_NAME) {
+                assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            }
+        }
+    }
+
+    @DisplayName("Should filter rules based on maxRuleVersion")
+    @CommonTest
+    fun filterRulesBasedOnMaxRuleVersion(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            withCleanSources()
+            //language=Groovy
+            buildGradle.appendText(
+                """
+                ktlint {
+                    version = "1.8.0"
+                    maxRuleVersion = "0.1.0"
+                }
+                """.trimIndent()
+            )
+
+            // With maxRuleVersion set to 0.1.0, almost no rules should be loaded
+            // so the check should pass even with potentially problematic code
+            build(CHECK_PARENT_TASK_NAME) {
+                assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            }
+        }
+    }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation100Test.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintInvocation100Test.kt
@@ -1,0 +1,118 @@
+package org.jlleitschuh.gradle.ktlint.worker
+
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.SinceKtlint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class KtLintInvocation100Test {
+
+    @Test
+    fun `rule without SinceKtlint annotation is always included`() {
+        val ruleProvider = RuleProvider { RuleWithoutAnnotation() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.0.0")).isTrue()
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, true, "1.0.0")).isTrue()
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, null)).isTrue()
+    }
+
+    @Test
+    fun `stable rule within version limit is included`() {
+        val ruleProvider = RuleProvider { RuleStable100() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.5.0")).isTrue()
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.0.0")).isTrue()
+    }
+
+    @Test
+    fun `stable rule exceeding version limit is excluded`() {
+        val ruleProvider = RuleProvider { RuleStable150() }
+        val ruleClass = ruleProvider.createNewRuleInstance()::class.java
+        val annotations = ruleClass.getAnnotationsByType(SinceKtlint::class.java).toList()
+        println("DEBUG: Found ${annotations.size} annotations on ${ruleClass.simpleName}")
+        annotations.forEach { println("  Version: ${it.version}, Status: ${it.status}") }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.0.0")).isFalse()
+    }
+
+    @Test
+    fun `experimental rule is excluded when experimental rules disabled`() {
+        val ruleProvider = RuleProvider { RuleExperimental100() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.5.0")).isFalse()
+    }
+
+    @Test
+    fun `experimental rule is included when experimental rules enabled`() {
+        val ruleProvider = RuleProvider { RuleExperimental100() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, true, "1.5.0")).isTrue()
+    }
+
+    @Test
+    fun `experimental rule exceeding version is excluded even with experimental enabled`() {
+        val ruleProvider = RuleProvider { RuleExperimental150() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, true, "1.0.0")).isFalse()
+    }
+
+    @Test
+    fun `rule with multiple annotations is included if any annotation matches`() {
+        val ruleProvider = RuleProvider { RuleMultipleAnnotations() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.2.0")).isTrue()
+    }
+
+    @Test
+    fun `rule with no matching annotations is excluded`() {
+        val ruleProvider = RuleProvider { RuleMultipleAnnotations() }
+
+        // RuleMultipleAnnotations has both 1.0.0 and 1.5.0, so with max 1.0.0, the first annotation matches
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, "1.0.0")).isTrue()
+    }
+
+    @Test
+    fun `no version limit includes all stable rules`() {
+        val ruleProvider = RuleProvider { RuleStable150() }
+
+        assertThat(KtLintInvocation100.isRuleCompatibleWithFilters(ruleProvider, false, null)).isTrue()
+    }
+
+    class RuleWithoutAnnotation : Rule(
+        ruleId = RuleId("test-set:no-annotation"),
+        about = About()
+    )
+
+    @SinceKtlint("1.0.0", SinceKtlint.Status.STABLE)
+    class RuleStable100 : Rule(
+        ruleId = RuleId("test-set:stable-one-zero-zero"),
+        about = About()
+    )
+
+    @SinceKtlint("1.5.0", SinceKtlint.Status.STABLE)
+    class RuleStable150 : Rule(
+        ruleId = RuleId("test-set:stable-one-five-zero"),
+        about = About()
+    )
+
+    @SinceKtlint("1.0.0", SinceKtlint.Status.EXPERIMENTAL)
+    class RuleExperimental100 : Rule(
+        ruleId = RuleId("test-set:experimental-one-zero-zero"),
+        about = About()
+    )
+
+    @SinceKtlint("1.5.0", SinceKtlint.Status.EXPERIMENTAL)
+    class RuleExperimental150 : Rule(
+        ruleId = RuleId("test-set:experimental-one-five-zero"),
+        about = About()
+    )
+
+    @SinceKtlint("1.0.0", SinceKtlint.Status.STABLE)
+    @SinceKtlint("1.5.0", SinceKtlint.Status.STABLE)
+    class RuleMultipleAnnotations : Rule(
+        ruleId = RuleId("test-set:multiple"),
+        about = About()
+    )
+}


### PR DESCRIPTION
Address the feature request in #942

## Summary
Adds `maxRuleVersion` configuration to allow filtering rules based on their `@SinceKtlint` version annotation.

## Changes
- Add `maxRuleVersion` property to `KtlintExtension`
- Implement version compatibility checking with semantic versioning support
- Filter rules in `KtLintInvocation100` based on `maxRuleVersion` setting
- Add comprehensive tests and documentation

More context in the issue mentioned above.
