### PR TITLE
Disable Configuration Cache in generated pre-commit Gradle call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Kotlin 2.4.0 support [#1059](https://github.com/JLLeitschuh/ktlint-gradle/pull/1059) (No changes needed, just updated tests)
 - Clean up workaround for Gradle 6 [#1068](https://github.com/JLLeitschuh/ktlint-gradle/pull/1068)
+- Disable Configuration Cache in generated pre-commit Gradle call [#995](https://github.com/JLLeitschuh/ktlint-gradle/pull/995)
 
 ## [14.2.0] - 2026-03-12
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
@@ -36,7 +36,7 @@ private fun generateGradleCommand(
     } else {
         "./gradlew"
     }
-    return "$gradleCommand --quiet $taskName -P$FILTER_INCLUDE_PROPERTY_NAME=\"${'$'}CHANGED_FILES\""
+    return "$gradleCommand --quiet --no-configuration-cache $taskName -P$FILTER_INCLUDE_PROPERTY_NAME=\"${'$'}CHANGED_FILES\""
 }
 
 private fun generateGitCommand(


### PR DESCRIPTION
internalKtlintGitFilter is part of the cache key, and it changes with every commit, so getting a cache hit is extremely unlikely.

If you execute the commit hook (in the form before my changes) with Configuration Cache enabled, you will see:
```
Calculating task graph as configuration cache cannot be reused because the set of Gradle properties has changed: the value of 'internalKtlintGitFilter' was changed.
```