### PR TITLE
Log issues at `ERROR` level with `ignoreFailures = false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Log issues at `ERROR` level when `ignoreFailures = false` [#1038](https://github.com/JLLeitschuh/ktlint-gradle/pull/1038)
+
 ## [14.2.0] - 2026-03-12
 
 - Make plugin compatible with Isolated Projects [#1032](https://github.com/JLLeitschuh/ktlint-gradle/pull/1032)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Kotlin 2.4.0 support [#1059](https://github.com/JLLeitschuh/ktlint-gradle/pull/1059) (No changes needed, just updated tests)
 - Clean up workaround for Gradle 6 [#1068](https://github.com/JLLeitschuh/ktlint-gradle/pull/1068)
+- Log issues at `ERROR` level when `ignoreFailures = false` [#1038](https://github.com/JLLeitschuh/ktlint-gradle/pull/1038)
 
 ## [14.2.0] - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ ktlint {
     android = false
     outputToConsole = true
     outputColorName = "RED"
-    ignoreFailures = true
+    ignoreFailures = true // ignoring failures also decreases the log level from ERROR to WARN
     enableExperimentalRules = true
     additionalEditorconfigFile = file("/some/additional/.editorconfig")  // not supported with ktlint 0.47+
     additionalEditorconfig = [ // not supported until ktlint 0.49
@@ -373,7 +373,7 @@ configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
     android.set(false)
     outputToConsole.set(true)
     outputColorName.set("RED")
-    ignoreFailures.set(true)
+    ignoreFailures.set(true) // ignoring failures also decreases the log level from ERROR to WARN
     enableExperimentalRules.set(true)
     additionalEditorconfigFile.set(file("/some/additional/.editorconfig")) // not supported with ktlint 0.47+
     additionalEditorconfig.set( // not supported until ktlint 0.49

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -72,7 +73,10 @@ open class KtlintExtension @Inject internal constructor(
     /**
      * Whether or not to allow the build to continue if there are warnings;
      * defaults to {@code false}, as for any other static code analysis tool.
-     * <p>
+     *
+     * When set to `true`, issues are logged with [LogLevel.WARN] so that they're not printed when
+     * Gradle is invoked with `--quiet`. Otherwise, issues are logged with [LogLevel.ERROR].
+     *
      * Example: `ignoreFailures = true`
      */
     val ignoreFailures: Property<Boolean> = objectFactory.property { set(false) }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/ConsoleReportWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/ConsoleReportWorkAction.kt
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.workers.WorkAction
@@ -42,14 +43,16 @@ internal abstract class ConsoleReportWorkAction : WorkAction<ConsoleReportWorkAc
         }
 
         val isLintErrorsFound = lintErrors.values.flatten().isNotEmpty()
+        val ignoreFailures = parameters.ignoreFailures.getOrElse(false)
         if (parameters.outputToConsole.getOrElse(false) && isLintErrorsFound) {
+            val logLevel = if (ignoreFailures) LogLevel.WARN else LogLevel.ERROR
             val verbose = parameters.verbose.get()
             lintErrors.forEach { (filePath, errors) ->
-                errors.forEach { it.logError(filePath, verbose) }
+                errors.forEach { it.logError(logLevel, filePath, verbose) }
             }
         }
 
-        if (!parameters.ignoreFailures.getOrElse(false) && isLintErrorsFound) {
+        if (!ignoreFailures && isLintErrorsFound) {
             val reportsPaths = parameters
                 .generatedReportsPaths
                 .files.joinToString(separator = "\n") { it.absolutePath.prefixIfNot("|- ") }
@@ -64,6 +67,7 @@ internal abstract class ConsoleReportWorkAction : WorkAction<ConsoleReportWorkAc
     }
 
     private fun SerializableLintError.logError(
+        logLevel: LogLevel,
         filePath: String,
         verbose: Boolean
     ) {
@@ -73,7 +77,7 @@ internal abstract class ConsoleReportWorkAction : WorkAction<ConsoleReportWorkAc
         } else {
             detail
         }
-        logger.warn("$filePath:$line:$col $errorDetail$verboseSuffix")
+        logger.log(logLevel, "$filePath:$line:$col $errorDetail$verboseSuffix")
     }
 
     internal interface ConsoleReportParameters : WorkParameters {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -36,6 +36,21 @@ class KtlintPluginTest : AbstractPluginTest() {
         }
     }
 
+    @DisplayName("Should pass on failing sources with ignoreFailures=true")
+    @CommonTest
+    fun passOnStyleViolationWithIgnoreFailures(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            buildGradle.appendText(
+                """
+                    ktlint.ignoreFailures = true
+                """.trimIndent()
+            )
+            withFailingSources()
+
+            build(CHECK_PARENT_TASK_NAME)
+        }
+    }
+
     @DisplayName("Should succeed check on clean sources")
     @CommonTest
     fun passCleanSources(gradleVersion: GradleVersion) {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -51,6 +51,39 @@ class KtlintPluginTest : AbstractPluginTest() {
         }
     }
 
+    @DisplayName("Should log issues at \"ERROR\" level with ignoreFailures=false")
+    @CommonTest
+    fun logIssuesAtErrorLevel(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            withFailingSources()
+
+            buildAndFail(CHECK_PARENT_TASK_NAME, "--quiet") {
+                assertThat(output).contains("Unnecessary long whitespace")
+            }
+        }
+    }
+
+    @DisplayName("Should log issues at \"WARNING\" level with ignoreFailures=true")
+    @CommonTest
+    fun logIssuesAtWarnLevelWithIgnoreFailures(gradleVersion: GradleVersion) {
+        project(gradleVersion) {
+            buildGradle.appendText(
+                """
+                    ktlint.ignoreFailures = true
+                """.trimIndent()
+            )
+            withFailingSources()
+
+            build(CHECK_PARENT_TASK_NAME, "--warn") {
+                assertThat(output).contains("Unnecessary long whitespace")
+            }
+
+            build(CHECK_PARENT_TASK_NAME, "--quiet", "--rerun-tasks") {
+                assertThat(output).doesNotContain("Unnecessary long whitespace")
+            }
+        }
+    }
+
     @DisplayName("Should succeed check on clean sources")
     @CommonTest
     fun passCleanSources(gradleVersion: GradleVersion) {


### PR DESCRIPTION
# What

The issues causing a build failure are most relevant, even when the user requests a quiet output.

Gradle plugins that print the issues causing a failure at `ERROR` level include:

<details>
<summary>Android Gradle Plugin (lint)</summary>

````
my-project % ./gradlew lint --quiet --rerun-tasks --console plain
Wrote HTML report to file:///Users/user/workspace/my-project/app/build/reports/lint-results-debug.html
Lint found 1 error. First failure:
/Users/user/workspace/my-project/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml:2: Error: The application adaptive icon is missing a monochrome tag [MonochromeLauncherIcon]
<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
^


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lintDebug'.
> Lint found errors in the project; aborting build.

  Fix the issues identified by lint, or create a baseline to see only new errors.
  To create a baseline, run `gradlew updateLintBaseline` after adding the following to the module's build.gradle file:
  ```
  android {
      lint {
          baseline = file("lint-baseline.xml")
      }
  }
  ```
  For more details, see https://developer.android.com/studio/write/lint#snapshot

  /Users/user/workspace/my-project/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml:2: Error: The application adaptive icon is missing a monochrome tag [MonochromeLauncherIcon]
  <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
  ^
  1 error

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 6s
````

</details>

<details>
<summary>io.gitlab.arturbosch.detekt</summary>

```
my-project % ./gradlew detekt --quiet --rerun-tasks --console plain
/Users/user/workspace/my-project/module/src/commonMain/kotlin/Hello.kt:34:5: The function Hello is too long (61). The maximum length is 60. [LongMethod]


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':module:detekt'.
> Analysis failed with 1 weighted issues.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
```
</details>

## Current ktlint-gradle behavior

Currently, when Gradle is invoked with log level `QUIET`, the issues causing a failure are missing from **ktlint-gradle**'s output.

## Proposed behavior

**ktlint-gradle** should log issues at `ERROR` level instead.

This PR results in the following output change when Gradle is invoked with `--quiet`:
```diff
  project % ./gradlew ktlintCheck --no-scan --rerun-tasks --quiet --console plain
+ /Users/user/workspace/project/module/src/main/kotlin/Hello.kt:5:30 Missing newline before "}" (standard:wrapping)
+ /Users/user/workspace/project/module/src/main/kotlin/Hello.kt:5:31 Missing newline before '}' (standard:statement-wrapping)

  FAILURE: Build failed with an exception.

  * What went wrong:
  Execution failed for task ':module:ktlintMainSourceSetCheck'.
  > A failure occurred while executing org.jlleitschuh.gradle.ktlint.worker.ConsoleReportWorkAction
     > KtLint found code style violations. Please see the following reports:
       - /Users/user/workspace/project/module/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.xml
       - /Users/user/workspace/project/module/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt
       - /Users/user/workspace/project/module/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.csv

  * Try:
  > Run with --stacktrace option to get the stack trace.
  > Run with --info or --debug option to get more log output.
  > Get more help at https://help.gradle.org.

  BUILD FAILED in 9s
```
The output remains unchanged when any other log level is requested, or when no log level is requested (default).

# Reference

https://docs.gradle.org/current/userguide/logging.html#logLevels