### PR TITLE
Bind max test Gradle version to current Gradle

### DIFF
--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/TestAnnotations.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/TestAnnotations.kt
@@ -24,10 +24,15 @@ object TestVersions {
         else -> "7.6.3"
     }
 
-    val maxSupportedGradleVersion = when (majorJavaVersion) {
+    private val maxGradleVersionForJava = when (majorJavaVersion) {
         in Int.MIN_VALUE..16 -> "8.14.3" // gradle 9 requires Java 17
         else -> "9.5.1"
     }
+
+    val maxSupportedGradleVersion = minOf(
+        GradleVersion.current(),
+        GradleVersion.version(maxGradleVersionForJava)
+    ).version
 
     val pluginVersion = System.getProperty("project.version")
         ?: KtlintPlugin::class.java.`package`.implementationVersion

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/TestVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/testdsl/TestVersionsTest.kt
@@ -1,0 +1,14 @@
+package org.jlleitschuh.gradle.ktlint.testdsl
+
+import org.gradle.util.GradleVersion
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TestVersionsTest {
+    @Test
+    fun maxSupportedGradleVersionDoesNotExceedCurrentGradleVersion() {
+        assertTrue(
+            GradleVersion.version(TestVersions.maxSupportedGradleVersion) <= GradleVersion.current()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- use GradleVersion.current() for the test DSL max supported Gradle version
- add a focused unit test for the TestVersions max Gradle version

Fixes #556.

## Test
- ./gradlew.bat --no-daemon --console=plain --max-workers=1 :plugin:compileKotlin
- ./gradlew.bat --no-daemon --console=plain --max-workers=1 :plugin:compileTestKotlin
- ./gradlew.bat --no-daemon --console=plain --max-workers=1 :plugin:test --tests org.jlleitschuh.gradle.ktlint.testdsl.TestVersionsTest