### PR TITLE
Clean up workaround for Gradle 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - Kotlin 2.4.0 support [#1059](https://github.com/JLLeitschuh/ktlint-gradle/pull/1059) (No changes needed, just updated tests)
+- Clean up workaround for Gradle 6 [#1068](https://github.com/JLLeitschuh/ktlint-gradle/pull/1068)
 
 ## [14.2.0] - 2026-03-12
 

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt
@@ -134,7 +134,6 @@ internal fun createKtLintReporterConfiguration(
 
 internal fun createKtLintBaselineReporterConfiguration(
     target: Project,
-    extension: KtlintExtension,
     ktLintConfiguration: Configuration
 ): Configuration = target
     .configurations
@@ -146,28 +145,4 @@ internal fun createKtLintBaselineReporterConfiguration(
         isCanBeConsumed = false
 
         shouldResolveConsistentlyWith(ktLintConfiguration)
-
-        //     withDependencies {
-        // Workaround for gradle 6 https://github.com/gradle/gradle/issues/13255
-        val oldProp = target.objects.listProperty(Dependency::class.java)
-        dependencies.addAllLater(
-            oldProp.value(
-                extension.version.map { version ->
-                    val ktlintVersion = extension.version.get()
-                    val ktlintSemver = SemVer.parse(ktlintVersion)
-                    if (ktlintSemver >= SemVer(1, 0, 0)) {
-                        // Baseline reporter maven coordinates changed in 1.0
-                        listOf(
-                            target.dependencies.create("com.pinterest.ktlint:ktlint-cli-reporter-baseline:$version"),
-                            // this transitive dep was introduced in ktlint 1.0, but for some reason, it is not picked up automatically
-                            target.dependencies.create("io.github.oshai:kotlin-logging:5.1.0")
-                        )
-                    } else {
-                        // Baseline reporter is only available starting 0.41.0 release
-                        listOf(target.dependencies.create("com.pinterest.ktlint:ktlint-reporter-baseline:$version"))
-                    }
-                }
-            )
-        )
-        //      }
     }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPlugin.kt
@@ -197,7 +197,6 @@ open class KtlintPlugin : Plugin<Project> {
         val ktlintReporterConfiguration: Configuration = createKtLintReporterConfiguration(target, extension, ktlintConfiguration)
         val ktlintBaselineReporterConfiguration: Configuration = createKtLintBaselineReporterConfiguration(
             target,
-            extension,
             ktlintConfiguration
         )
         val loadReportersTask = createLoadReportersTask(this)


### PR DESCRIPTION
PR for issue https://github.com/JLLeitschuh/ktlint-gradle/issues/893

Since the minimal supported Gradle version is now 7.4, the workaround for Gradle 6 in [plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/Configurations.kt] can now be removed.

It's not only obsolete code at this point, but also hardcodes dependencies on old versions of kotlin-logging and sarif4k libraries.